### PR TITLE
Much faster writeMessage and simpler packed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ pbf.pos = fooPos;
 pbf.readMessage(readFoo);
 ```
 
-Basic reading methods:
+Scalar reading methods:
 
 * `readVarint()`
 * `readSVarint()`
@@ -130,8 +130,21 @@ Basic reading methods:
 * `readDouble()`
 * `readString()`
 * `readBytes()`
-* `readPacked(type)`
+* `readString()`
+* `readBytes()`
 * `skip(value)`
+
+Packed reading methods:
+
+* `readPackedVarint()`
+* `readPackedSVarint()`
+* `readPackedFixed32()`
+* `readPackedFixed64()`
+* `readPackedSFixed32()`
+* `readPackedSFixed64()`
+* `readPackedBoolean()`
+* `readPackedFloat()`
+* `readPackedDouble()`
 
 #### Writing
 
@@ -158,12 +171,23 @@ Field writing methods:
 * `writePacked(tag, type, items)`
 * `writeMessage(tag, pbf)`
 
+Packed field writing methods:
+
+* `writePackedVarint(tag, val)`
+* `writePackedSVarint(tag, val)`
+* `writePackedSFixed32(tag, val)`
+* `writePackedSFixed64(tag, val)`
+* `writePackedBoolean(tag, val)`
+* `writePackedFloat(tag, val)`
+* `writePackedDouble(tag, val)`
+
 Scalar writing methods:
 
 * `writeVarint(val)`
 * `writeSVarint(val)`
 * `writeSFixed32(val)`
 * `writeSFixed64(val)`
+* `writeBoolean(val)`
 * `writeFloat(val)`
 * `writeDouble(val)`
 * `writeString(val)`
@@ -182,6 +206,8 @@ For an example of a real-world usage of the library, see [vector-tile-js](https:
 
 #### master (unreleased)
 
+- Replaced `readPacked` and `writePacked` methods that accept type as a string
+  with `readPackedVarint`, etc. for each type (for better performance).
 - Significantly improved encoding performance (the tile encoding benchmark is now 2.6x faster).
 - Significantly improved encoding and decoding performance in browsers (faster Buffer shim).
 - Added optional `start` and `end` arguments to `writeBytes`.

--- a/bench/bench.html
+++ b/bench/bench.html
@@ -45,9 +45,9 @@
         }
         function readFeature(tag, feature, pbf) {
             if (tag === 1) feature.id = pbf.readVarint();
-            else if (tag === 2) feature.tags = pbf.readPacked('Varint');
+            else if (tag === 2) feature.tags = pbf.readPackedVarint();
             else if (tag === 3) feature.type = pbf.readVarint();
-            else if (tag === 4) feature.geometry = pbf.readPacked('Varint');
+            else if (tag === 4) feature.geometry = pbf.readPackedVarint();
         }
         function readValue(pbf) {
             var end = pbf.readVarint() + pbf.pos;
@@ -98,9 +98,9 @@
         function encodeFeature(feature) {
             var pbf = new Pbf();
             pbf.writeVarintField(1, feature.id);
-            pbf.writePacked(2, 'Varint', feature.tags);
+            pbf.writePackedVarint(2, feature.tags);
             pbf.writeVarintField(3, feature.type);
-            pbf.writePacked(4, 'Varint', feature.geometry);
+            pbf.writePackedVarint(4, feature.geometry);
             return pbf;
         }
         function encodeValue(value) {

--- a/bench/bench.html
+++ b/bench/bench.html
@@ -74,37 +74,32 @@
         function encodeLayers(layers) {
             var pbf = new Pbf();
             for (var i = 0; i < layers.length; i++) {
-                pbf.writeMessage(3, encodeLayer(layers[i]));
+                pbf.writeMessage(3, encodeLayer, layers[i]);
             }
             return pbf.finish();
         }
-        function encodeLayer(layer) {
-            var pbf = new Pbf();
+        function encodeLayer(layer, pbf) {
             pbf.writeStringField(1, layer.name);
 
             for (var i = 0; i < layer.features.length; i++) {
-                pbf.writeMessage(2, encodeFeature(layer.features[i]));
+                pbf.writeMessage(2, encodeFeature, layer.features[i]);
             }
             for (i = 0; i < layer.keys.length; i++) {
                 pbf.writeStringField(3, layer.keys[i]);
             }
             for (i = 0; i < layer.values.length; i++) {
-                pbf.writeMessage(4, encodeValue(layer.values[i]));
+                pbf.writeMessage(4, encodeValue, layer.values[i]);
             }
             pbf.writeVarintField(5, layer.extent);
             pbf.writeVarintField(15, layer.version);
-            return pbf;
         }
-        function encodeFeature(feature) {
-            var pbf = new Pbf();
+        function encodeFeature(feature, pbf) {
             pbf.writeVarintField(1, feature.id);
             pbf.writePackedVarint(2, feature.tags);
             pbf.writeVarintField(3, feature.type);
             pbf.writePackedVarint(4, feature.geometry);
-            return pbf;
         }
-        function encodeValue(value) {
-            var pbf = new Pbf();
+        function encodeValue(value, pbf) {
             if (typeof value === 'string') pbf.writeStringField(1, value);
             else if (typeof value === 'number') {
                 if (value % 1 === 0) { // integer
@@ -112,7 +107,6 @@
                     else pbf.writeSVarintField(6, value);
                 } else pbf.writeDoubleField(3, value);
             } else if (typeof value === 'boolean') pbf.writeBooleanField(7, value);
-            return pbf;
         }
 
     </script>

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -57,9 +57,9 @@ function readLayer(tag, layer, pbf) {
 }
 function readFeature(tag, feature, pbf) {
     if (tag === 1) feature.id = pbf.readVarint();
-    else if (tag === 2) feature.tags = pbf.readPacked('Varint');
+    else if (tag === 2) feature.tags = pbf.readPackedVarint();
     else if (tag === 3) feature.type = pbf.readVarint();
-    else if (tag === 4) feature.geometry = pbf.readPacked('Varint');
+    else if (tag === 4) feature.geometry = pbf.readPackedVarint();
 }
 function readValue(tag, value, pbf) {
     if (tag === 1) value.value = pbf.readString();
@@ -100,9 +100,9 @@ function encodeLayer(layer) {
 function encodeFeature(feature) {
     var pbf = new Pbf();
     pbf.writeVarintField(1, feature.id);
-    pbf.writePacked(2, 'Varint', feature.tags);
+    pbf.writePackedVarint(2, feature.tags);
     pbf.writeVarintField(3, feature.type);
-    pbf.writePacked(4, 'Varint', feature.geometry);
+    pbf.writePackedVarint(4, feature.geometry);
     return pbf;
 }
 function encodeValue(value) {

--- a/index.js
+++ b/index.js
@@ -127,17 +127,51 @@ Pbf.prototype = {
         return buffer;
     },
 
-    readPacked: function(type) {
-        var end = this.readVarint() + this.pos,
-            arr = [];
-        if (type === 'Varint')        while (this.pos < end) arr.push(this.readVarint());
-        else if (type === 'SVarint')  while (this.pos < end) arr.push(this.readSVarint());
-        else if (type === 'Float')    while (this.pos < end) arr.push(this.readFloat());
-        else if (type === 'Double')   while (this.pos < end) arr.push(this.readDouble());
-        else if (type === 'Fixed32')  while (this.pos < end) arr.push(this.readFixed32());
-        else if (type === 'SFixed32') while (this.pos < end) arr.push(this.readSFixed32());
-        else if (type === 'Fixed64')  while (this.pos < end) arr.push(this.readFixed64());
-        else if (type === 'SFixed64') while (this.pos < end) arr.push(this.readSFixed64());
+    // verbose for performance reasons; doesn't affect gzipped size
+
+    readPackedVarint: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readVarint());
+        return arr;
+    },
+    readPackedSVarint: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readSVarint());
+        return arr;
+    },
+    readPackedBoolean: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readBoolean());
+        return arr;
+    },
+    readPackedFloat: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readFloat());
+        return arr;
+    },
+    readPackedDouble: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readDouble());
+        return arr;
+    },
+    readPackedFixed32: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readFixed32());
+        return arr;
+    },
+    readPackedSFixed32: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readSFixed32());
+        return arr;
+    },
+    readPackedFixed64: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readFixed64());
+        return arr;
+    },
+    readPackedSFixed64: function() {
+        var end = this.readVarint() + this.pos, arr = [];
+        while (this.pos < end) arr.push(this.readSFixed64());
         return arr;
     },
 
@@ -173,25 +207,6 @@ Pbf.prototype = {
         this.length = this.pos;
         this.pos = 0;
         return this.buf.slice(0, this.length);
-    },
-
-    writePacked: function(tag, type, items) {
-        if (!items.length) return;
-
-        var len = items.length,
-            message = new Pbf(len * 4),
-            i = 0;
-
-        if (type === 'Varint')        for (; i < len; i++) message.writeVarint(items[i]);
-        else if (type === 'SVarint')  for (; i < len; i++) message.writeSVarint(items[i]);
-        else if (type === 'Float')    for (; i < len; i++) message.writeFloat(items[i]);
-        else if (type === 'Double')   for (; i < len; i++) message.writeDouble(items[i]);
-        else if (type === 'Fixed32')  for (; i < len; i++) message.writeFixed32(items[i]);
-        else if (type === 'SFixed32') for (; i < len; i++) message.writeSFixed32(items[i]);
-        else if (type === 'Fixed64')  for (; i < len; i++) message.writeFixed64(items[i]);
-        else if (type === 'SFixed64') for (; i < len; i++) message.writeSFixed64(items[i]);
-
-        this.writeMessage(tag, message);
     },
 
     writeFixed32: function(val) {
@@ -293,6 +308,52 @@ Pbf.prototype = {
             this.buf[this.pos + i] = buffer[i];
         }
         this.pos += len;
+    },
+
+    writePackedVarint: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 2);
+        for (var i = 0; i < len; i++) message.writeVarint(items[i]);
+        this.writeMessage(tag, message);
+    },
+    writePackedSVarint: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 2);
+        for (var i = 0; i < len; i++) message.writeSVarint(items[i]);
+        this.writeMessage(tag, message);
+    },
+    writePackedBoolean: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 2);
+        for (var i = 0; i < len; i++) message.writeBoolean(items[i]);
+        this.writeMessage(tag, message);
+    },
+    writePackedFloat: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 4);
+        for (var i = 0; i < len; i++) message.writeFloat(items[i]);
+        this.writeMessage(tag, message);
+    },
+    writePackedDouble: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 8);
+        for (var i = 0; i < len; i++) message.writeDouble(items[i]);
+        this.writeMessage(tag, message);
+    },
+    writePackedFixed32: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 4);
+        for (var i = 0; i < len; i++) message.writeFixed32(items[i]);
+        this.writeMessage(tag, message);
+    },
+    writePackedSFixed32: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 4);
+        for (var i = 0; i < len; i++) message.writeSFixed32(items[i]);
+        this.writeMessage(tag, message);
+    },
+    writePackedFixed64: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 8);
+        for (var i = 0; i < len; i++) message.writeFixed64(items[i]);
+        this.writeMessage(tag, message);
+    },
+    writePackedSFixed64: function(tag, items) {
+        var len = items.length, message = new Pbf(len * 8);
+        for (var i = 0; i < len; i++) message.writeSFixed64(items[i]);
+        this.writeMessage(tag, message);
     },
 
     writeMessage: function(tag, pbf) {

--- a/test/pbf.test.js
+++ b/test/pbf.test.js
@@ -138,20 +138,25 @@ test('readDouble', function(t) {
 });
 
 test('readPacked and writePacked', function(t) {
-    var buf = new Pbf();
-    buf.writePacked(1, 'Varint', []);
-    t.equal(buf.pos, 0);
-
     var testNumbers2 = testNumbers.slice(0, 10);
 
     ['Varint', 'SVarint', 'Float', 'Double', 'Fixed32', 'SFixed32', 'Fixed64', 'SFixed64'].forEach(function (type) {
         var buf = new Pbf();
-        buf.writePacked(1, type, testNumbers2);
+        buf['writePacked' + type](1, testNumbers2);
         buf.finish();
         buf.readFields(function readField(tag) {
-            if (tag === 1) t.same(buf.readPacked(type), testNumbers2, 'packed ' + type);
+            if (tag === 1) t.same(buf['readPacked' + type](), testNumbers2, 'packed ' + type);
             else t.fail('wrong tag encountered: ' + tag);
         });
+    });
+
+    var buf = new Pbf();
+    buf.writePackedBoolean(1, testNumbers2);
+    buf.finish();
+    buf.readFields(function readField(tag) {
+        if (tag === 1) t.same(buf.readPackedBoolean(),
+            [true, false, false, true, true, true, true, true, true, true], 'packed Boolean');
+        else t.fail('wrong tag encountered: ' + tag);
     });
 
     t.end();

--- a/test/pbf.test.js
+++ b/test/pbf.test.js
@@ -327,10 +327,10 @@ test('field writing methods', function (t) {
     buf.writeDoubleField(7, 123);
     buf.writeBooleanField(8, true);
     buf.writeBytesField(9, [1, 2, 3]);
-
-    var message = new Pbf();
-    message.writeBooleanField(1, true);
-    buf.writeMessage(10, message);
+    buf.writeMessage(10, function () {
+        buf.writeBooleanField(1, true);
+        buf.writePackedVarint(2, testNumbers);
+    });
 
     buf.writeSFixed32Field(11, -123);
     buf.writeSFixed64Field(12, -256);


### PR DESCRIPTION
Closes #19, ref #20.

1. A different `writeMessage` mechanism that accepts function rather than a `Pbf` instance and leads to huge encoding performance improvement.
2. Replaced `readPacked` and `writePacked` with `readPackedVarint`, etc. for better performance (70% faster decoding in browsers) and simpler API.

While the code is a bit more verbose now, the library size grew from 2.99KB to just 3.12KB gzipped — not much. Now on to the benchmarks:

Node encoding:

```
encode vector tile with pbf x 64.65 ops/sec ±1.52% (60 runs sampled) # before
encode vector tile with pbf x 172 ops/sec ±1.16% (82 runs sampled) # after
```

Browser encoding:

```
encode vector tile 10 times: 154ms # before
encode vector tile 10 times: 38ms # after
```

Browser decoding:

```
decode vector tile 10 times: 75ms # before
decode vector tile 10 times: 35ms # after
```
