### PR TITLE
Proto to JavaScript compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ The resulting code is pretty short and easy to understand, so you can customize 
 
 ## Changelog
 
+#### 1.3.0 (Feb 5, 2015)
+
+- Added `pbf` binary that compiles `.proto` files into `Pbf`-based JavaScript modules.
+
 #### 1.2.0 (Jan 5, 2015)
 
 ##### Breaking API changes

--- a/README.md
+++ b/README.md
@@ -8,9 +8,25 @@ Designed to be a building block for writing customized decoders and encoders.
 If you need an all-purpose protobuf JS library that does most of the work for you,
 take a look at [protocol-buffers](https://github.com/mafintosh/protocol-buffers) too.
 
-## Example
+## Examples
 
-#### Reading
+#### Using Compiled Code
+
+Install `pbf` and compile a JavaScript module from a `.proto` file:
+
+```bash
+$ npm install -g pbf
+$ pbf test.proto > test.js
+```
+
+Then read and write objects using the module like this:
+
+```js
+var obj = Test.read(new Pbf(buffer)); // read
+var buffer = Test.write(obj, new Pbf()); // write
+```
+
+#### Custom Reading
 
 ```js
 var data = new Pbf(buffer).readFields(readData, {});
@@ -26,7 +42,7 @@ function readLayer(tag, layer, pbf) {
 }
 ```
 
-#### Writing
+#### Custom Writing
 
 ```js
 var pbf = new Pbf();
@@ -43,6 +59,7 @@ function writeLayer(layer, pbf) {
     pbf.writeVarintField(2, layer.size);
 }
 ```
+
 
 ## Install
 
@@ -218,6 +235,26 @@ Misc methods:
 * `destroy()` - dispose the buffer
 
 For an example of a real-world usage of the library, see [vector-tile-js](https://github.com/mapbox/vector-tile-js).
+
+
+## Proto Schema to JavaScript
+
+If installed globally, `pbf` provides a binary that compiles `proto` files into JavaScript modules. Usage:
+
+```bash
+$ pbf <proto_path> [--no-write] [--no-read] [--browser]
+```
+
+The `--no-write` and `--no-read` switches remove corresponding code in the output.
+The `--browser` switch makes the module work in browsers instead of Node.
+
+The resulting module exports each message by name with the following methods:
+
+* `read(pbf)` - decodes an object from the given `Pbf` instance
+* `write(obj, pbf)` - encodes an object into the given `Pbf` instance (usually empty)
+
+The resulting code is pretty short and easy to understand, so you can customize it easily.
+
 
 ## Changelog
 

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -5,8 +5,8 @@ var Benchmark = require('benchmark'),
     protobuf = require('protocol-buffers'),
     vt = require('./vector_tile'),
     Pbf = require('../'),
-    readTile = vt.readTile,
-    writeTile = vt.writeTile;
+    readTile = vt.Tile.read,
+    writeTile = vt.Tile.write;
 
 var Tile = protobuf(fs.readFileSync(__dirname + '/vector_tile.proto')).Tile,
     data = fs.readFileSync(__dirname + '/../test/fixtures/12665.vector.pbf'),
@@ -15,6 +15,8 @@ var Tile = protobuf(fs.readFileSync(__dirname + '/vector_tile.proto')).Tile,
 var tile = readTile(new Pbf(data)),
     tileJSON = JSON.stringify(tile),
     tile2 = Tile.decode(data);
+
+writeTile(tile, new Pbf());
 
 suite
 .add('decode vector tile with pbf', function() {

--- a/bench/vector_tile.js
+++ b/bench/vector_tile.js
@@ -1,32 +1,37 @@
 'use strict';
 
-if (typeof exports !== 'undefined') {
-    exports.readTile = readTile;
-    exports.writeTile = writeTile;
+// Tile ========================================
+
+var Tile = exports.Tile = {read: readTile, write: writeTile};
+
+Tile.GeomType = {
+    "UNKNOWN": 0,
+    "POINT": 1,
+    "LINESTRING": 2,
+    "POLYGON": 3
+};
+
+function readTile(pbf, end) {
+    return pbf.readFields(readTileField, {"layers": []}, end);
 }
 
-// decoding vector tile
-
-function readTile(pbf) {
-    return pbf.readFields(readTileField, {layers: []});
-}
 function readTileField(tag, tile, pbf) {
-    if (tag === 3) tile.layers.push(pbf.readMessage(readLayerField, {features: [], keys: [], values: []}));
+    if (tag === 3) tile.layers.push(readLayer(pbf, pbf.readVarint() + pbf.pos));
 }
-function readLayerField(tag, layer, pbf) {
-    if (tag === 1) layer.name = pbf.readString();
-    else if (tag === 2) layer.features.push(pbf.readMessage(readFeatureField, {}));
-    else if (tag === 3) layer.keys.push(pbf.readString());
-    else if (tag === 4) layer.values.push(pbf.readMessage(readValueField, {}));
-    else if (tag === 5) layer.extent = pbf.readVarint();
-    else if (tag === 15) layer.version = pbf.readVarint();
+
+function writeTile(tile, pbf) {
+    var i;
+    if (tile.layers !== undefined) for (i = 0; i < tile.layers.length; i++) pbf.writeMessage(3, writeLayer, tile.layers[i]);
 }
-function readFeatureField(tag, feature, pbf) {
-    if (tag === 1) feature.id = pbf.readVarint();
-    else if (tag === 2) feature.tags = pbf.readPackedVarint();
-    else if (tag === 3) feature.type = pbf.readVarint();
-    else if (tag === 4) feature.geometry = pbf.readPackedVarint();
+
+// Value ========================================
+
+Tile.Value = {read: readValue, write: writeValue};
+
+function readValue(pbf, end) {
+    return pbf.readFields(readValueField, {}, end);
 }
+
 function readValueField(tag, value, pbf) {
     if (tag === 1) value.string_value = pbf.readString();
     else if (tag === 2) value.float_value = pbf.readFloat();
@@ -37,32 +42,63 @@ function readValueField(tag, value, pbf) {
     else if (tag === 7) value.bool_value = pbf.readBoolean();
 }
 
-// encoding vector tile
+function writeValue(value, pbf) {
+    if (value.string_value !== undefined) pbf.writeString(1, value.string_value);
+    if (value.float_value !== undefined) pbf.writeFloat(2, value.float_value);
+    if (value.double_value !== undefined) pbf.writeDouble(3, value.double_value);
+    if (value.int_value !== undefined) pbf.writeVarint(4, value.int_value);
+    if (value.uint_value !== undefined) pbf.writeVarint(5, value.uint_value);
+    if (value.sint_value !== undefined) pbf.writeSVarint(6, value.sint_value);
+    if (value.bool_value !== undefined) pbf.writeBoolean(7, value.bool_value);
+}
 
-function writeTile(tile, pbf) {
-    if (tile.layers !== undefined) for (var i = 0; i < tile.layers.length; i++) pbf.writeMessage(3, writeLayer, tile.layers[i]);
+// Feature ========================================
+
+Tile.Feature = {read: readFeature, write: writeFeature};
+
+function readFeature(pbf, end) {
+    var feature = pbf.readFields(readFeatureField, {}, end);
+    if (feature.type === undefined) feature.type = "UNKNOWN";
+    return feature;
 }
-function writeLayer(layer, pbf) {
-    if (layer.name !== undefined) pbf.writeStringField(1, layer.name);
-    var i;
-    if (layer.features !== undefined) for (i = 0; i < layer.features.length; i++) pbf.writeMessage(2, writeFeature, layer.features[i]);
-    if (layer.keys !== undefined) for (i = 0; i < layer.keys.length; i++) pbf.writeStringField(3, layer.keys[i]);
-    if (layer.values !== undefined) for (i = 0; i < layer.values.length; i++) pbf.writeMessage(4, writeValue, layer.values[i]);
-    if (layer.extent !== undefined) pbf.writeVarintField(5, layer.extent);
-    if (layer.version !== undefined) pbf.writeVarintField(15, layer.version);
+
+function readFeatureField(tag, feature, pbf) {
+    if (tag === 1) feature.id = pbf.readVarint();
+    else if (tag === 2) feature.tags = pbf.readPackedVarint();
+    else if (tag === 3) feature.type = pbf.readVarint();
+    else if (tag === 4) feature.geometry = pbf.readPackedVarint();
 }
+
 function writeFeature(feature, pbf) {
-    if (feature.id !== undefined) pbf.writeVarintField(1, feature.id);
+    if (feature.id !== undefined) pbf.writeVarint(1, feature.id);
     if (feature.tags !== undefined) pbf.writePackedVarint(2, feature.tags);
-    if (feature.type !== undefined) pbf.writeVarintField(3, feature.type);
+    if (feature.type !== undefined) pbf.writeVarint(3, feature.type);
     if (feature.geometry !== undefined) pbf.writePackedVarint(4, feature.geometry);
 }
-function writeValue(value, pbf) {
-    if (value.string_value !== undefined) pbf.writeStringField(1, value.string_value);
-    if (value.float_value !== undefined) pbf.writeFloatField(2, value.float_value);
-    if (value.double_value !== undefined) pbf.writeDoubleField(3, value.double_value);
-    if (value.int_value !== undefined) pbf.writeVarintField(4, value.int_value);
-    if (value.uint_value !== undefined) pbf.writeVarintField(5, value.uint_value);
-    if (value.sint_value !== undefined) pbf.writeSVarintField(6, value.sint_value);
-    if (value.bool_value !== undefined) pbf.writeBooleanField(7, value.bool_value);
+
+// Layer ========================================
+
+Tile.Layer = {read: readLayer, write: writeLayer};
+
+function readLayer(pbf, end) {
+    return pbf.readFields(readLayerField, {"features": [], "keys": [], "values": []}, end);
+}
+
+function readLayerField(tag, layer, pbf) {
+    if (tag === 15) layer.version = pbf.readVarint();
+    else if (tag === 1) layer.name = pbf.readString();
+    else if (tag === 2) layer.features.push(readFeature(pbf, pbf.readVarint() + pbf.pos));
+    else if (tag === 3) layer.keys.push(pbf.readString());
+    else if (tag === 4) layer.values.push(readValue(pbf, pbf.readVarint() + pbf.pos));
+    else if (tag === 5) layer.extent = pbf.readVarint();
+}
+
+function writeLayer(layer, pbf) {
+    if (layer.version !== undefined) pbf.writeVarint(15, layer.version);
+    if (layer.name !== undefined) pbf.writeString(1, layer.name);
+    var i;
+    if (layer.features !== undefined) for (i = 0; i < layer.features.length; i++) pbf.writeMessage(2, writeFeature, layer.features[i]);
+    if (layer.keys !== undefined) for (i = 0; i < layer.keys.length; i++) pbf.writeString(3, layer.keys[i]);
+    if (layer.values !== undefined) for (i = 0; i < layer.values.length; i++) pbf.writeMessage(4, writeValue, layer.values[i]);
+    if (layer.extent !== undefined) pbf.writeVarint(5, layer.extent);
 }

--- a/bin/pbf
+++ b/bin/pbf
@@ -9,12 +9,15 @@ if (process.argv.length > 2) {
     compileMessages(resolve.sync(process.argv[2]), 'exports', {},
         process.argv.indexOf('--no-read') === -1,
         process.argv.indexOf('--no-write') === -1);
+} else {
+    console.warn('Error: no path to proto file given.');
 }
 
 function compileMessage(message, parentName, enums, read, write) {
     var name = message.name,
         nameLow = name.toLowerCase(),
-        nameCap = name.charAt(0).toUpperCase() + name.substr(1);
+        nameCap = name.charAt(0).toUpperCase() + name.substr(1),
+        i, field;
 
     console.log('\n// %s ========================================\n', name);
 
@@ -26,7 +29,7 @@ function compileMessage(message, parentName, enums, read, write) {
         '%s.%s = {%s};\n', parentName, name, methods.join(', '));
 
     if (message.enums.length) {
-        for (var i = 0; i < message.enums.length; i++) {
+        for (i = 0; i < message.enums.length; i++) {
             var en = message.enums[i];
             enums[en.name] = true;
             console.log('%s.%s = ' + JSON.stringify(en.values, null, 4) + ';\n', name, en.name);
@@ -36,10 +39,10 @@ function compileMessage(message, parentName, enums, read, write) {
     if (read) {
         console.log('function read%s(pbf, end) {', nameCap);
         console.log('    var %s = pbf.readFields(read%sField, %s, end);', nameLow, nameCap, repeatedDest(message.fields));
-        for (var i = 0; i < message.fields.length; i++) {
-            var field = message.fields[i];
-            if (enums[field.type] && field.options['default'] !== undefined) {
-                console.log('    if (%s.%s === undefined) %s.%s = ' + JSON.stringify(field.options['default']) + ';',
+        for (i = 0; i < message.fields.length; i++) {
+            field = message.fields[i];
+            if (enums[field.type] && field.options.default !== undefined) {
+                console.log('    if (%s.%s === undefined) %s.%s = ' + JSON.stringify(field.options.default) + ';',
                     nameLow, field.name, nameLow, field.name);
             }
         }
@@ -48,8 +51,8 @@ function compileMessage(message, parentName, enums, read, write) {
 
         console.log('function read%sField(tag, %s, pbf) {', nameCap, nameLow);
 
-        for (var i = 0; i < message.fields.length; i++) {
-            var field = message.fields[i];
+        for (i = 0; i < message.fields.length; i++) {
+            field = message.fields[i];
             console.log('    ' + (i ? 'else if' : 'if') + ' (tag === %d) %s.%s = %s;',
                 field.tag, nameLow, field.name, readMethod(field, enums));
         }
@@ -61,8 +64,8 @@ function compileMessage(message, parentName, enums, read, write) {
     if (write) {
         console.log('function write%s(%s, pbf) {', nameCap, nameLow);
         var iDeclared;
-        for (var i = 0; i < message.fields.length; i++) {
-            var field = message.fields[i];
+        for (i = 0; i < message.fields.length; i++) {
+            field = message.fields[i];
             if (!iDeclared && field.repeated) {
                 console.log('    var i;');
                 iDeclared = true;

--- a/bin/pbf
+++ b/bin/pbf
@@ -18,7 +18,7 @@ function compileMessage(message, parentName, enums, read, write) {
     var name = message.name,
         nameLow = name.toLowerCase(),
         nameCap = name.charAt(0).toUpperCase() + name.substr(1),
-        i, field;
+        i, field, part;
 
     console.log('\n// %s ========================================\n', name);
 
@@ -39,23 +39,38 @@ function compileMessage(message, parentName, enums, read, write) {
 
     if (read) {
         console.log('function read%s(pbf, end) {', nameCap);
-        console.log('    var %s = pbf.readFields(read%sField, %s, end);', nameLow, nameCap, repeatedDest(message.fields));
+        part = 'pbf.readFields(read' + nameCap + 'Field, ' + repeatedDest(message.fields) + ', end);';
+        var hasDefaults = false;
         for (i = 0; i < message.fields.length; i++) {
             field = message.fields[i];
             if (enums[field.type] && field.options.default !== undefined) {
-                console.log('    if (%s.%s === undefined) %s.%s = ' + JSON.stringify(field.options.default) + ';',
-                    nameLow, field.name, nameLow, field.name);
+                hasDefaults = true;
+                break;
             }
         }
-        console.log('    return %s;', nameLow);
-        console.log('}');
+        if (hasDefaults) {
+            console.log('    var ' + nameLow + ' = ' + part);
+            for (i = 0; i < message.fields.length; i++) {
+                field = message.fields[i];
+                if (enums[field.type] && field.options.default !== undefined) {
+                    console.log('    if (%s.%s === undefined) %s.%s = ' + JSON.stringify(field.options.default) + ';',
+                        nameLow, field.name, nameLow, field.name);
+                }
+            }
+            console.log('    return %s;', nameLow);
+        } else {
+            console.log('    return ' + part);
+        }
+        console.log('}\n');
 
         console.log('function read%sField(tag, %s, pbf) {', nameCap, nameLow);
 
         for (i = 0; i < message.fields.length; i++) {
             field = message.fields[i];
-            console.log('    ' + (i ? 'else if' : 'if') + ' (tag === %d) %s.%s = %s;',
-                field.tag, nameLow, field.name, readMethod(field, enums));
+            part = field.repeated && !field.options.packed ? '.push(' + readMethod(field, enums) + ')' :
+                    ' = ' + readMethod(field, enums);
+            console.log('    ' + (i ? 'else if' : 'if') + ' (tag === %d) %s.%s%s;',
+                field.tag, nameLow, field.name, part);
         }
         console.log('}');
     }
@@ -67,7 +82,7 @@ function compileMessage(message, parentName, enums, read, write) {
         var iDeclared;
         for (i = 0; i < message.fields.length; i++) {
             field = message.fields[i];
-            if (!iDeclared && field.repeated) {
+            if (!iDeclared && field.repeated && !field.options.packed) {
                 console.log('    var i;');
                 iDeclared = true;
             }
@@ -90,37 +105,41 @@ function compileMessages(parent, parentName, enums, read, write) {
 function repeatedDest(fields) {
     var repeated = [];
     for (var i = 0; i < fields.length; i++) {
-        if (fields[i].repeated) repeated.push('"' + fields[i].name + '": []');
+        if (fields[i].repeated && !fields[i].options.packed) repeated.push('"' + fields[i].name + '": []');
     }
     return '{' + repeated.join(', ') + '}';
 }
 
 function readMethod(field, enums) {
     var type = field.type;
+
+    var prefix = 'pbf.read';
+    if (field.options.packed) prefix += 'Packed';
+
     switch (field.type) {
-    case 'string':   return 'pbf.readString()';
-    case 'float':    return 'pbf.readFloat()';
-    case 'double':   return 'pbf.readDouble()';
-    case 'bool':     return 'pbf.readBoolean()';
+    case 'string':   return prefix + 'String()';
+    case 'float':    return prefix + 'Float()';
+    case 'double':   return prefix + 'Double()';
+    case 'bool':     return prefix + 'Boolean()';
     case 'enum':
     case 'uint32':
     case 'uint64':
     case 'int32':
-    case 'int64':    return 'pbf.readVarint()';
+    case 'int64':    return prefix + 'Varint()';
     case 'sint32':
-    case 'sint64':   return 'pbf.readSVarint()';
-    case 'fixed32':  return 'pbf.readFixed32()';
-    case 'fixed64':  return 'pbf.readFixed64()';
-    case 'sfixed32': return 'pbf.readSFixed32()';
-    case 'sfixed64': return 'pbf.readSFixed64()';
-    case 'bytes':    return 'pbf.readBytes()';
-    default:         return enums[field.type] ? 'pbf.readVarint()' :
+    case 'sint64':   return prefix + 'SVarint()';
+    case 'fixed32':  return prefix + 'Fixed32()';
+    case 'fixed64':  return prefix + 'Fixed64()';
+    case 'sfixed32': return prefix + 'SFixed32()';
+    case 'sfixed64': return prefix + 'SFixed64()';
+    case 'bytes':    return prefix + 'Bytes()';
+    default:         return enums[field.type] ? prefix + 'Varint()' :
                         'read' + type.charAt(0).toUpperCase() + type.substr(1) + '(pbf, pbf.readVarint() + pbf.pos)';
     }
 }
 
-function writeMethod(tag, type, name, repeated, packed) {
-    if (repeated) return repeatedWriteMethod(tag, type, name);
+function writeMethod(tag, type, name, repeated, packed, enums) {
+    if (repeated && !packed) return repeatedWriteMethod(tag, type, name, enums);
 
     var prefix = 'pbf.write';
     if (packed) prefix += 'Packed';
@@ -144,11 +163,12 @@ function writeMethod(tag, type, name, repeated, packed) {
     case 'sfixed32': return prefix + 'SFixed32' + postfix;
     case 'sfixed64': return prefix + 'SFixed64' + postfix;
     case 'bytes':    return prefix + 'Bytes' + postfix;
-    default:         return prefix + 'Message(' + tag + ', write' +
+    default:         return enums[type] ? prefix + 'Varint' + postfix :
+                                prefix + 'Message(' + tag + ', write' +
                                 type.charAt(0).toUpperCase() + type.substr(1) + ', ' + name + ')';
     }
 }
 
-function repeatedWriteMethod(tag, type, name) {
-    return 'for (i = 0; i < ' + name + '.length; i++) ' + writeMethod(tag, type, name + '[i]');
+function repeatedWriteMethod(tag, type, name, enums) {
+    return 'for (i = 0; i < ' + name + '.length; i++) ' + writeMethod(tag, type, name + '[i]', false, false, enums);
 }

--- a/bin/pbf
+++ b/bin/pbf
@@ -7,45 +7,46 @@ var resolve = require('resolve-protobuf-schema');
 if (process.argv.length > 2) {
     console.log('\'use strict\';');
     compileMessages(resolve.sync(process.argv[2]), 'exports', {},
-    	process.argv.indexOf('--no-read') === -1,
-    	process.argv.indexOf('--no-write') === -1);
+        process.argv.indexOf('--no-read') === -1,
+        process.argv.indexOf('--no-write') === -1);
 }
 
 function compileMessage(message, parentName, enums, read, write) {
     var name = message.name,
-        nameLow = name.toLowerCase();
+        nameLow = name.toLowerCase(),
+        nameCap = name.charAt(0).toUpperCase() + name.substr(1);
 
     console.log('\n// %s ========================================\n', name);
 
     var methods = [];
-    if (read) methods.push('read: read' + name);
-    if (write) methods.push('write: write' + name);
+    if (read) methods.push('read: read' + nameCap);
+    if (write) methods.push('write: write' + nameCap);
 
     console.log((message.messages.length ? 'var ' + name + ' = ' : '') +
-    	'%s.%s = {%s};\n', parentName, name, methods.join(', '));
+        '%s.%s = {%s};\n', parentName, name, methods.join(', '));
 
     if (message.enums.length) {
-    	for (var i = 0; i < message.enums.length; i++) {
-    		var en = message.enums[i];
-    		enums[en.name] = true;
-    		console.log('%s.%s = ' + JSON.stringify(en.values, null, 4) + ';\n', name, en.name);
-    	}
+        for (var i = 0; i < message.enums.length; i++) {
+            var en = message.enums[i];
+            enums[en.name] = true;
+            console.log('%s.%s = ' + JSON.stringify(en.values, null, 4) + ';\n', name, en.name);
+        }
     }
 
     if (read) {
-        console.log('function read%s(pbf, end) {', name);
-        console.log('    var %s = pbf.readFields(read%sField, %s, end);', nameLow, name, repeatedDest(message.fields));
+        console.log('function read%s(pbf, end) {', nameCap);
+        console.log('    var %s = pbf.readFields(read%sField, %s, end);', nameLow, nameCap, repeatedDest(message.fields));
         for (var i = 0; i < message.fields.length; i++) {
-        	var field = message.fields[i];
-        	if (enums[field.type] && field.options['default'] !== undefined) {
-        		console.log('    if (%s.%s === undefined) %s.%s = ' + JSON.stringify(field.options['default']) + ';',
-        			nameLow, field.name, nameLow, field.name);
-        	}
+            var field = message.fields[i];
+            if (enums[field.type] && field.options['default'] !== undefined) {
+                console.log('    if (%s.%s === undefined) %s.%s = ' + JSON.stringify(field.options['default']) + ';',
+                    nameLow, field.name, nameLow, field.name);
+            }
         }
         console.log('    return %s;', nameLow);
         console.log('}');
 
-        console.log('function read%sField(tag, %s, pbf) {', name, nameLow);
+        console.log('function read%sField(tag, %s, pbf) {', nameCap, nameLow);
 
         for (var i = 0; i < message.fields.length; i++) {
             var field = message.fields[i];
@@ -58,17 +59,17 @@ function compileMessage(message, parentName, enums, read, write) {
     if (read && write) console.log('');
 
     if (write) {
-        console.log('function write%s(%s, pbf) {', name, nameLow);
+        console.log('function write%s(%s, pbf) {', nameCap, nameLow);
         var iDeclared;
         for (var i = 0; i < message.fields.length; i++) {
             var field = message.fields[i];
             if (!iDeclared && field.repeated) {
-            	console.log('    var i;');
-            	iDeclared = true;
+                console.log('    var i;');
+                iDeclared = true;
             }
             console.log('    if (%s.%s !== undefined) %s;', nameLow, field.name,
                 writeMethod(field.tag, field.type, nameLow + '.' + field.name,
-                	field.repeated, field.options.packed, enums));
+                    field.repeated, field.options.packed, enums));
         }
         console.log('}');
     }
@@ -91,6 +92,7 @@ function repeatedDest(fields) {
 }
 
 function readMethod(field, enums) {
+    var type = field.type;
     switch (field.type) {
     case 'string':   return 'pbf.readString()';
     case 'float':    return 'pbf.readFloat()';
@@ -109,7 +111,7 @@ function readMethod(field, enums) {
     case 'sfixed64': return 'pbf.readSFixed64()';
     case 'bytes':    return 'pbf.readBytes()';
     default:         return enums[field.type] ? 'pbf.readVarint()' :
-    						'read' + field.type + '(pbf, pbf.readVarint() + pbf.pos)';
+                        'read' + type.charAt(0).toUpperCase() + type.substr(1) + '(pbf, pbf.readVarint() + pbf.pos)';
     }
 }
 
@@ -138,7 +140,8 @@ function writeMethod(tag, type, name, repeated, packed) {
     case 'sfixed32': return prefix + 'SFixed32' + postfix;
     case 'sfixed64': return prefix + 'SFixed64' + postfix;
     case 'bytes':    return prefix + 'Bytes' + postfix;
-    default:         return prefix + 'Message(' + tag + ', write' + type + ', ' + name + ')';
+    default:         return prefix + 'Message(' + tag + ', write' +
+                                type.charAt(0).toUpperCase() + type.substr(1) + ', ' + name + ')';
     }
 }
 

--- a/bin/pbf
+++ b/bin/pbf
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var resolve = require('resolve-protobuf-schema');
+
+if (process.argv.length > 2) {
+    console.log('\'use strict\';');
+    compileMessages(resolve.sync(process.argv[2]), 'exports', {},
+    	process.argv.indexOf('--no-read') === -1,
+    	process.argv.indexOf('--no-write') === -1);
+}
+
+function compileMessage(message, parentName, enums, read, write) {
+    var name = message.name,
+        nameLow = name.toLowerCase();
+
+    console.log('\n// %s ========================================\n', name);
+
+    var methods = [];
+    if (read) methods.push('read: read' + name);
+    if (write) methods.push('write: write' + name);
+
+    console.log((message.messages.length ? 'var ' + name + ' = ' : '') +
+    	'%s.%s = {%s};\n', parentName, name, methods.join(', '));
+
+    if (message.enums.length) {
+    	for (var i = 0; i < message.enums.length; i++) {
+    		var en = message.enums[i];
+    		enums[en.name] = true;
+    		console.log('%s.%s = ' + JSON.stringify(en.values, null, 4) + ';\n', name, en.name);
+    	}
+    }
+
+    if (read) {
+        console.log('function read%s(pbf, end) {', name);
+        console.log('    var %s = pbf.readFields(read%sField, %s, end);', nameLow, name, repeatedDest(message.fields));
+        for (var i = 0; i < message.fields.length; i++) {
+        	var field = message.fields[i];
+        	if (enums[field.type] && field.options['default'] !== undefined) {
+        		console.log('    if (%s.%s === undefined) %s.%s = ' + JSON.stringify(field.options['default']) + ';',
+        			nameLow, field.name, nameLow, field.name);
+        	}
+        }
+        console.log('    return %s;', nameLow);
+        console.log('}');
+
+        console.log('function read%sField(tag, %s, pbf) {', name, nameLow);
+
+        for (var i = 0; i < message.fields.length; i++) {
+            var field = message.fields[i];
+            console.log('    ' + (i ? 'else if' : 'if') + ' (tag === %d) %s.%s = %s;',
+                field.tag, nameLow, field.name, readMethod(field, enums));
+        }
+        console.log('}');
+    }
+
+    if (read && write) console.log('');
+
+    if (write) {
+        console.log('function write%s(%s, pbf) {', name, nameLow);
+        var iDeclared;
+        for (var i = 0; i < message.fields.length; i++) {
+            var field = message.fields[i];
+            if (!iDeclared && field.repeated) {
+            	console.log('    var i;');
+            	iDeclared = true;
+            }
+            console.log('    if (%s.%s !== undefined) %s;', nameLow, field.name,
+                writeMethod(field.tag, field.type, nameLow + '.' + field.name,
+                	field.repeated, field.options.packed, enums));
+        }
+        console.log('}');
+    }
+
+    compileMessages(message, name, enums, read, write);
+}
+
+function compileMessages(parent, parentName, enums, read, write) {
+    for (var i = 0; i < parent.messages.length; i++) {
+        compileMessage(parent.messages[i], parentName, enums, read, write);
+    }
+}
+
+function repeatedDest(fields) {
+    var repeated = [];
+    for (var i = 0; i < fields.length; i++) {
+        if (fields[i].repeated) repeated.push('"' + fields[i].name + '": []');
+    }
+    return '{' + repeated.join(', ') + '}';
+}
+
+function readMethod(field, enums) {
+    switch (field.type) {
+    case 'string':   return 'pbf.readString()';
+    case 'float':    return 'pbf.readFloat()';
+    case 'double':   return 'pbf.readDouble()';
+    case 'bool':     return 'pbf.readBoolean()';
+    case 'enum':
+    case 'uint32':
+    case 'uint64':
+    case 'int32':
+    case 'int64':    return 'pbf.readVarint()';
+    case 'sint32':
+    case 'sint64':   return 'pbf.readSVarint()';
+    case 'fixed32':  return 'pbf.readFixed32()';
+    case 'fixed64':  return 'pbf.readFixed64()';
+    case 'sfixed32': return 'pbf.readSFixed32()';
+    case 'sfixed64': return 'pbf.readSFixed64()';
+    case 'bytes':    return 'pbf.readBytes()';
+    default:         return enums[field.type] ? 'pbf.readVarint()' :
+    						'read' + field.type + '(pbf, pbf.readVarint() + pbf.pos)';
+    }
+}
+
+function writeMethod(tag, type, name, repeated, packed) {
+    if (repeated) return repeatedWriteMethod(tag, type, name);
+
+    var prefix = 'pbf.write';
+    if (packed) prefix += 'Packed';
+
+    var postfix = '(' + tag + ', ' + name + ')';
+
+    switch (type) {
+    case 'string':   return prefix + 'String' + postfix;
+    case 'float':    return prefix + 'Float' + postfix;
+    case 'double':   return prefix + 'Double' + postfix;
+    case 'bool':     return prefix + 'Boolean' + postfix;
+    case 'enum':
+    case 'uint32':
+    case 'uint64':
+    case 'int32':
+    case 'int64':    return prefix + 'Varint' + postfix;
+    case 'sint32':
+    case 'sint64':   return prefix + 'SVarint' + postfix;
+    case 'fixed32':  return prefix + 'Fixed32' + postfix;
+    case 'fixed64':  return prefix + 'Fixed64' + postfix;
+    case 'sfixed32': return prefix + 'SFixed32' + postfix;
+    case 'sfixed64': return prefix + 'SFixed64' + postfix;
+    case 'bytes':    return prefix + 'Bytes' + postfix;
+    default:         return prefix + 'Message(' + tag + ', write' + type + ', ' + name + ')';
+    }
+}
+
+function repeatedWriteMethod(tag, type, name) {
+    return 'for (i = 0; i < ' + name + '.length; i++) ' + writeMethod(tag, type, name + '[i]');
+}

--- a/bin/pbf
+++ b/bin/pbf
@@ -6,7 +6,8 @@ var resolve = require('resolve-protobuf-schema');
 
 if (process.argv.length > 2) {
     console.log('\'use strict\';');
-    compileMessages(resolve.sync(process.argv[2]), 'exports', {},
+    compileMessages(resolve.sync(process.argv[2]),
+        process.argv.indexOf('--browser') !== -1 ? 'window' : 'exports', {},
         process.argv.indexOf('--no-read') === -1,
         process.argv.indexOf('--no-write') === -1);
 } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbf",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "a low-level, lightweight protocol buffers implementation in JavaScript",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "build-min": "mkdirp dist && browserify index.js -s Pbf | uglifyjs -c warnings=false -m > dist/pbf.js",
     "build-dev": "mkdirp dist && browserify index.js -d -s Pbf > dist/pbf-dev.js"
   },
+  "bin": {
+    "pbf": "bin/pbf"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:mapbox/pbf.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "a low-level, lightweight protocol buffers implementation in JavaScript",
   "main": "index.js",
   "scripts": {
-    "test": "eslint index.js buffer.js test/*.js && tape test/*.test.js | faucet",
+    "test": "eslint index.js buffer.js test/*.js bin/pbf && tape test/*.test.js | faucet",
     "cov": "istanbul cover tape test/*.test.js && coveralls < ./coverage/lcov.info",
     "build-min": "mkdirp dist && browserify index.js -s Pbf | uglifyjs -c warnings=false -m > dist/pbf.js",
     "build-dev": "mkdirp dist && browserify index.js -d -s Pbf > dist/pbf-dev.js"
@@ -31,7 +31,8 @@
   },
   "homepage": "https://github.com/mapbox/pbf",
   "dependencies": {
-    "ieee754": "~1.1.4"
+    "ieee754": "~1.1.4",
+    "resolve-protobuf-schema": "^1.0.2"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",


### PR DESCRIPTION
A Node script that takes a `proto` file and turns it into a JS module for writing and reading `Pbf`. Closes #22. Usage:

```bash
$ pbf vector_tile.proto > vector_tile.js
```

Also accepts `--no-write` and `--no-read` arguments that strip corresponding code.

Generated code looks like this: https://github.com/mapbox/pbf/blob/protoc/bench/vector_tile.js

- [ ] resolve nested type names
- [ ] avoid function name clashes with namespaced types