### PR TITLE
add readVarint64 method that handles negative int64 values

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Scalar reading methods:
 
 * `readVarint()`
 * `readSVarint()`
+* `readVarint64()` (`readVarint` version that handles negative `int64` values)
 * `readFixed32()`
 * `readFixed64()`
 * `readSFixed32()`
@@ -257,6 +258,10 @@ The resulting code is pretty short and easy to understand, so you can customize 
 
 
 ## Changelog
+
+#### 1.3.2 (Mar 5, 2015)
+
+- Added `readVarint64` method for proper decoding of negative `int64`-encoded values.
 
 #### 1.3.1 (Feb 20, 2015)
 

--- a/bench/vector_tile.js
+++ b/bench/vector_tile.js
@@ -36,7 +36,7 @@ function readValueField(tag, value, pbf) {
     if (tag === 1) value.string_value = pbf.readString();
     else if (tag === 2) value.float_value = pbf.readFloat();
     else if (tag === 3) value.double_value = pbf.readDouble();
-    else if (tag === 4) value.int_value = pbf.readVarint();
+    else if (tag === 4) value.int_value = pbf.readVarint64();
     else if (tag === 5) value.uint_value = pbf.readVarint();
     else if (tag === 6) value.sint_value = pbf.readSVarint();
     else if (tag === 7) value.bool_value = pbf.readBoolean();

--- a/index.js
+++ b/index.js
@@ -113,6 +113,8 @@ Pbf.prototype = {
             var pos = this.pos - 2;
             while (this.buf[pos] === 0xff) pos--; // skip padded bytes
 
+            if (pos < startPos) pos = startPos;
+
             var len = pos - startPos + 1,
                 buf = new Buffer(len);
 

--- a/test/pbf.test.js
+++ b/test/pbf.test.js
@@ -56,6 +56,22 @@ test('readVarint & writeVarint', function(t) {
     t.end();
 });
 
+test('readVarint64', function(t) {
+    var bytes = [0xc8,0xe8,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x01];
+    var buf = new Pbf(new Buffer(bytes));
+    t.equal(buf.readVarint64(), -3000);
+
+    bytes = [0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x01];
+    buf = new Pbf(new Buffer(bytes));
+    t.equal(buf.readVarint64(), -1);
+
+    bytes = [0xc8,0x01];
+    buf = new Pbf(new Buffer(bytes));
+    t.equal(buf.readVarint64(), 200);
+
+    t.end();
+});
+
 test('readVarint & writeVarint handle really big numbers', function(t) {
     var buf = new Pbf();
     var bigNum1 = Math.pow(2, 60);


### PR DESCRIPTION
Closes #27, related: https://github.com/mapbox/vector-tile-js/issues/21.