### PR TITLE
Improve reading/writing performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ Pbf.prototype = {
         b = buf[this.pos++]; val |= (b & 0x7f) << 14; if (b < 0x80) return val;
         b = buf[this.pos++]; val |= (b & 0x7f) << 21; if (b < 0x80) return val;
 
-        return readVarintExtension(val, this);
+        return readVarintRemainder(val, this);
     },
 
     readVarint64: function() {
@@ -250,7 +250,7 @@ Pbf.prototype = {
         val = +val;
 
         if (val > 0xfffffff) {
-            writeExtendedVarint(val, this);
+            writeBigVarint(val, this);
             return;
         }
 
@@ -374,7 +374,7 @@ Pbf.prototype = {
     }
 };
 
-function readVarintExtension(val, pbf) {
+function readVarintRemainder(val, pbf) {
     var buf = pbf.buf, b;
 
     b = buf[pbf.pos++]; val += (b & 0x7f) * 0x10000000;         if (b < 0x80) return val;
@@ -387,7 +387,7 @@ function readVarintExtension(val, pbf) {
     throw new Error('Expected varint not more than 10 bytes');
 }
 
-function writeExtendedVarint(val, pbf) {
+function writeBigVarint(val, pbf) {
     pbf.realloc(10);
 
     var maxPos = pbf.pos + 10;

--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ Pbf.prototype = {
         fn(obj, this);
         var len = this.pos - startPos;
 
-        reallocForRawMessage(startPos, len, this);
+        if (len >= 0x80) reallocForRawMessage(startPos, len, this);
 
         // finally, write the message length in the reserved place and restore the position
         this.pos = startPos - 1;
@@ -401,8 +401,6 @@ function writeBigVarint(val, pbf) {
 }
 
 function reallocForRawMessage(startPos, len, pbf) {
-    if (len <= 0x7f) return;
-
     var extraLen =
         len <= 0x3fff ? 1 :
         len <= 0x1fffff ? 2 :


### PR DESCRIPTION
Used various tricks to improve generic runtime performance.

Results on my machine as follows:

- before the change

```
decode vector tile with pbf x 858 ops/sec ±1.17% (90 runs sampled)
encode vector tile with pbf x 556 ops/sec ±1.46% (84 runs sampled)
```

- after the change

```
decode vector tile with pbf x 999 ops/sec ±1.13% (92 runs sampled)
encode vector tile with pbf x 638 ops/sec ±1.48% (84 runs sampled)
```

(both show ~15% improvement)