### PR TITLE
Set default values when decoding and omit default values when encoding

### DIFF
--- a/bench/vector_tile.js
+++ b/bench/vector_tile.js
@@ -26,7 +26,7 @@ Tile.GeomType = {
 Tile.Value = {};
 
 Tile.Value.read = function (pbf, end) {
-    return pbf.readFields(Tile.Value._readField, {}, end);
+    return pbf.readFields(Tile.Value._readField, {string_value: "", float_value: 0, double_value: 0, int_value: 0, uint_value: 0, sint_value: 0, bool_value: false}, end);
 };
 Tile.Value._readField = function (tag, obj, pbf) {
     if (tag === 1) obj.string_value = pbf.readString();
@@ -72,7 +72,7 @@ Tile.Feature.write = function (obj, pbf) {
 Tile.Layer = {};
 
 Tile.Layer.read = function (pbf, end) {
-    return pbf.readFields(Tile.Layer._readField, {version: 1, features: [], keys: [], values: [], extent: 4096}, end);
+    return pbf.readFields(Tile.Layer._readField, {version: 1, name: "", features: [], keys: [], values: [], extent: 4096}, end);
 };
 Tile.Layer._readField = function (tag, obj, pbf) {
     if (tag === 15) obj.version = pbf.readVarint();

--- a/bench/vector_tile.js
+++ b/bench/vector_tile.js
@@ -83,10 +83,10 @@ Tile.Layer._readField = function (tag, obj, pbf) {
     else if (tag === 5) obj.extent = pbf.readVarint();
 };
 Tile.Layer.write = function (obj, pbf) {
-    if (obj.version !== undefined && obj.version !== 1) pbf.writeVarintField(15, obj.version);
+    if (obj.version != undefined && obj.version !== 1) pbf.writeVarintField(15, obj.version);
     if (obj.name) pbf.writeStringField(1, obj.name);
     if (obj.features) for (var i = 0; i < obj.features.length; i++) pbf.writeMessage(2, Tile.Feature.write, obj.features[i]);
     if (obj.keys) for (i = 0; i < obj.keys.length; i++) pbf.writeStringField(3, obj.keys[i]);
     if (obj.values) for (i = 0; i < obj.values.length; i++) pbf.writeMessage(4, Tile.Value.write, obj.values[i]);
-    if (obj.extent !== undefined && obj.extent !== 4096) pbf.writeVarintField(5, obj.extent);
+    if (obj.extent != undefined && obj.extent !== 4096) pbf.writeVarintField(5, obj.extent);
 };

--- a/bench/vector_tile.js
+++ b/bench/vector_tile.js
@@ -52,7 +52,7 @@ Tile.Value.write = function (obj, pbf) {
 Tile.Feature = {};
 
 Tile.Feature.read = function (pbf, end) {
-    return pbf.readFields(Tile.Feature._readField, {type: "UNKNOWN"}, end);
+    return pbf.readFields(Tile.Feature._readField, {id: 0, type: 0}, end);
 };
 Tile.Feature._readField = function (tag, obj, pbf) {
     if (tag === 1) obj.id = pbf.readVarint();
@@ -72,7 +72,7 @@ Tile.Feature.write = function (obj, pbf) {
 Tile.Layer = {};
 
 Tile.Layer.read = function (pbf, end) {
-    return pbf.readFields(Tile.Layer._readField, {features: [], keys: [], values: []}, end);
+    return pbf.readFields(Tile.Layer._readField, {version: 1, features: [], keys: [], values: [], extent: 4096}, end);
 };
 Tile.Layer._readField = function (tag, obj, pbf) {
     if (tag === 15) obj.version = pbf.readVarint();

--- a/bench/vector_tile.js
+++ b/bench/vector_tile.js
@@ -11,7 +11,7 @@ Tile._readField = function (tag, obj, pbf) {
     if (tag === 3) obj.layers.push(Tile.Layer.read(pbf, pbf.readVarint() + pbf.pos));
 };
 Tile.write = function (obj, pbf) {
-    if (obj.layers !== undefined) for (var i = 0; i < obj.layers.length; i++) pbf.writeMessage(3, Tile.Layer.write, obj.layers[i]);
+    if (obj.layers) for (var i = 0; i < obj.layers.length; i++) pbf.writeMessage(3, Tile.Layer.write, obj.layers[i]);
 };
 
 Tile.GeomType = {
@@ -38,13 +38,13 @@ Tile.Value._readField = function (tag, obj, pbf) {
     else if (tag === 7) obj.bool_value = pbf.readBoolean();
 };
 Tile.Value.write = function (obj, pbf) {
-    if (obj.string_value !== undefined && obj.string_value.length !== 0) pbf.writeStringField(1, obj.string_value);
-    if (obj.float_value !== undefined && obj.float_value !== 0) pbf.writeFloatField(2, obj.float_value);
-    if (obj.double_value !== undefined && obj.double_value !== 0) pbf.writeDoubleField(3, obj.double_value);
-    if (obj.int_value !== undefined && obj.int_value !== 0) pbf.writeVarintField(4, obj.int_value);
-    if (obj.uint_value !== undefined && obj.uint_value !== 0) pbf.writeVarintField(5, obj.uint_value);
-    if (obj.sint_value !== undefined && obj.sint_value !== 0) pbf.writeSVarintField(6, obj.sint_value);
-    if (obj.bool_value !== undefined && obj.bool_value !== false) pbf.writeBooleanField(7, obj.bool_value);
+    if (obj.string_value) pbf.writeStringField(1, obj.string_value);
+    if (obj.float_value) pbf.writeFloatField(2, obj.float_value);
+    if (obj.double_value) pbf.writeDoubleField(3, obj.double_value);
+    if (obj.int_value) pbf.writeVarintField(4, obj.int_value);
+    if (obj.uint_value) pbf.writeVarintField(5, obj.uint_value);
+    if (obj.sint_value) pbf.writeSVarintField(6, obj.sint_value);
+    if (obj.bool_value) pbf.writeBooleanField(7, obj.bool_value);
 };
 
 // Tile.Feature ========================================
@@ -61,10 +61,10 @@ Tile.Feature._readField = function (tag, obj, pbf) {
     else if (tag === 4) obj.geometry = pbf.readPackedVarint();
 };
 Tile.Feature.write = function (obj, pbf) {
-    if (obj.id !== undefined && obj.id !== 0) pbf.writeVarintField(1, obj.id);
-    if (obj.tags !== undefined) pbf.writePackedVarint(2, obj.tags);
-    if (obj.type !== undefined && obj.type !== 0) pbf.writeVarintField(3, obj.type);
-    if (obj.geometry !== undefined) pbf.writePackedVarint(4, obj.geometry);
+    if (obj.id) pbf.writeVarintField(1, obj.id);
+    if (obj.tags) pbf.writePackedVarint(2, obj.tags);
+    if (obj.type) pbf.writeVarintField(3, obj.type);
+    if (obj.geometry) pbf.writePackedVarint(4, obj.geometry);
 };
 
 // Tile.Layer ========================================
@@ -84,9 +84,9 @@ Tile.Layer._readField = function (tag, obj, pbf) {
 };
 Tile.Layer.write = function (obj, pbf) {
     if (obj.version !== undefined && obj.version !== 1) pbf.writeVarintField(15, obj.version);
-    if (obj.name !== undefined && obj.name.length !== 0) pbf.writeStringField(1, obj.name);
-    if (obj.features !== undefined) for (var i = 0; i < obj.features.length; i++) pbf.writeMessage(2, Tile.Feature.write, obj.features[i]);
-    if (obj.keys !== undefined) for (i = 0; i < obj.keys.length; i++) pbf.writeStringField(3, obj.keys[i]);
-    if (obj.values !== undefined) for (i = 0; i < obj.values.length; i++) pbf.writeMessage(4, Tile.Value.write, obj.values[i]);
+    if (obj.name) pbf.writeStringField(1, obj.name);
+    if (obj.features) for (var i = 0; i < obj.features.length; i++) pbf.writeMessage(2, Tile.Feature.write, obj.features[i]);
+    if (obj.keys) for (i = 0; i < obj.keys.length; i++) pbf.writeStringField(3, obj.keys[i]);
+    if (obj.values) for (i = 0; i < obj.values.length; i++) pbf.writeMessage(4, Tile.Value.write, obj.values[i]);
     if (obj.extent !== undefined && obj.extent !== 4096) pbf.writeVarintField(5, obj.extent);
 };

--- a/bench/vector_tile.js
+++ b/bench/vector_tile.js
@@ -38,13 +38,13 @@ Tile.Value._readField = function (tag, obj, pbf) {
     else if (tag === 7) obj.bool_value = pbf.readBoolean();
 };
 Tile.Value.write = function (obj, pbf) {
-    if (obj.string_value !== undefined) pbf.writeStringField(1, obj.string_value);
-    if (obj.float_value !== undefined) pbf.writeFloatField(2, obj.float_value);
-    if (obj.double_value !== undefined) pbf.writeDoubleField(3, obj.double_value);
-    if (obj.int_value !== undefined) pbf.writeVarintField(4, obj.int_value);
-    if (obj.uint_value !== undefined) pbf.writeVarintField(5, obj.uint_value);
-    if (obj.sint_value !== undefined) pbf.writeSVarintField(6, obj.sint_value);
-    if (obj.bool_value !== undefined) pbf.writeBooleanField(7, obj.bool_value);
+    if (obj.string_value !== undefined && obj.string_value.length !== 0) pbf.writeStringField(1, obj.string_value);
+    if (obj.float_value !== undefined && obj.float_value !== 0) pbf.writeFloatField(2, obj.float_value);
+    if (obj.double_value !== undefined && obj.double_value !== 0) pbf.writeDoubleField(3, obj.double_value);
+    if (obj.int_value !== undefined && obj.int_value !== 0) pbf.writeVarintField(4, obj.int_value);
+    if (obj.uint_value !== undefined && obj.uint_value !== 0) pbf.writeVarintField(5, obj.uint_value);
+    if (obj.sint_value !== undefined && obj.sint_value !== 0) pbf.writeSVarintField(6, obj.sint_value);
+    if (obj.bool_value !== undefined && obj.bool_value !== false) pbf.writeBooleanField(7, obj.bool_value);
 };
 
 // Tile.Feature ========================================
@@ -61,9 +61,9 @@ Tile.Feature._readField = function (tag, obj, pbf) {
     else if (tag === 4) obj.geometry = pbf.readPackedVarint();
 };
 Tile.Feature.write = function (obj, pbf) {
-    if (obj.id !== undefined) pbf.writeVarintField(1, obj.id);
+    if (obj.id !== undefined && obj.id !== 0) pbf.writeVarintField(1, obj.id);
     if (obj.tags !== undefined) pbf.writePackedVarint(2, obj.tags);
-    if (obj.type !== undefined) pbf.writeVarintField(3, obj.type);
+    if (obj.type !== undefined && obj.type !== 0) pbf.writeVarintField(3, obj.type);
     if (obj.geometry !== undefined) pbf.writePackedVarint(4, obj.geometry);
 };
 
@@ -83,10 +83,10 @@ Tile.Layer._readField = function (tag, obj, pbf) {
     else if (tag === 5) obj.extent = pbf.readVarint();
 };
 Tile.Layer.write = function (obj, pbf) {
-    if (obj.version !== undefined) pbf.writeVarintField(15, obj.version);
-    if (obj.name !== undefined) pbf.writeStringField(1, obj.name);
+    if (obj.version !== undefined && obj.version !== 1) pbf.writeVarintField(15, obj.version);
+    if (obj.name !== undefined && obj.name.length !== 0) pbf.writeStringField(1, obj.name);
     if (obj.features !== undefined) for (var i = 0; i < obj.features.length; i++) pbf.writeMessage(2, Tile.Feature.write, obj.features[i]);
     if (obj.keys !== undefined) for (i = 0; i < obj.keys.length; i++) pbf.writeStringField(3, obj.keys[i]);
     if (obj.values !== undefined) for (i = 0; i < obj.values.length; i++) pbf.writeMessage(4, Tile.Value.write, obj.values[i]);
-    if (obj.extent !== undefined) pbf.writeVarintField(5, obj.extent);
+    if (obj.extent !== undefined && obj.extent !== 4096) pbf.writeVarintField(5, obj.extent);
 };

--- a/bench/vector_tile.proto
+++ b/bench/vector_tile.proto
@@ -1,4 +1,4 @@
-// Protocol Version 1
+syntax = "proto2";
 
 package vector_tile;
 

--- a/compile.js
+++ b/compile.js
@@ -60,9 +60,8 @@ function writeMessage(ctx, options) {
             var writeCode = field.repeated && !isPacked(field) ?
                 compileRepeatedWrite(ctx, field, numRepeated++) :
                 compileFieldWrite(ctx, field, field.name);
-            code += '    if (obj.' + field.name + ' !== undefined';
             code += getDefaultWriteTest(field);
-            code += ') ' + writeCode + ';\n';
+            code += writeCode + ';\n';
         }
         code += '};\n';
     }
@@ -285,20 +284,20 @@ function buildDefaults(ctx, syntax) {
 }
 
 function getDefaultWriteTest(field) {
-    var prefix = ' && obj.' + field.name;
     var def = field.options.default;
+    var code = '    if (obj.' + field.name;
 
-    // Special case for strings to avoid creating unnecessary strings
-    // and comparing.
-    if (def === '') {
-        return prefix + '.length !== 0';
+    if (!field.repeated) {
+        if (def === undefined || def) {
+            code += ' !== undefined';
+        }
+
+        if (def) {
+            code += ' && obj.' + field.name + ' !== ' + JSON.stringify(def);
+        }
     }
 
-    if (def !== undefined) {
-        return prefix + ' !== ' + JSON.stringify(def);
-    }
-
-    return '';
+    return code + ') ';
 }
 
 function isPacked(field) {

--- a/compile.js
+++ b/compile.js
@@ -216,6 +216,27 @@ function castDefaultValue(field, value) {
     }
 }
 
+function getDefaultValue(field) {
+    switch (field.type) {
+    case 'float':
+    case 'double':
+    case 'enum':
+    case 'uint32':
+    case 'uint64':
+    case 'int32':
+    case 'int64':
+    case 'sint32':
+    case 'sint64':
+    case 'fixed32':
+    case 'fixed64':
+    case 'sfixed32':
+    case 'sfixed64': return 0;
+    case 'string':   return '';
+    case 'bool':     return false;
+    default:         return undefined;
+    }
+}
+
 function setDefaultValue(ctx, field, syntax) {
     var options = field.options;
     var type = ctx[field.type];
@@ -224,14 +245,24 @@ function setDefaultValue(ctx, field, syntax) {
     // Proto3 does not support overriding defaults
     if (syntax === 3) {
         delete options.default;
+    }
 
-    // Convert enum strings to number
-    } else if (values) {
-        options.default = values[options.default];
+    // Set default for enum values
+    if (values) {
+        options.default = values[options.default] || 0;
 
     // Defaults are always strings, cast them to appropriate type
     } else if (options.default !== undefined) {
         options.default = castDefaultValue(field, options.default);
+
+    // Set field type appropriate default
+    } else {
+        options.default = getDefaultValue(field);
+    }
+
+    // Defaults not supported for repeated fields
+    if (field.repeated) {
+        delete options.default;
     }
 }
 

--- a/compile.js
+++ b/compile.js
@@ -60,7 +60,7 @@ function writeMessage(ctx, options) {
             var writeCode = field.repeated && !isPacked(field) ?
                 compileRepeatedWrite(ctx, field, numRepeated++) :
                 compileFieldWrite(ctx, field, field.name);
-            code += getDefaultWriteTest(field);
+            code += getDefaultWriteTest(ctx, field);
             code += writeCode + ';\n';
         }
         code += '};\n';
@@ -240,7 +240,7 @@ function getDefaultValue(field) {
 
 function setDefaultValue(ctx, field, syntax) {
     var options = field.options;
-    var type = ctx[field.type];
+    var type = getType(ctx, field);
     var values = type && type._proto.values;
 
     // Proto3 does not support overriding defaults
@@ -283,13 +283,14 @@ function buildDefaults(ctx, syntax) {
     return ctx;
 }
 
-function getDefaultWriteTest(field) {
+function getDefaultWriteTest(ctx, field) {
     var def = field.options.default;
+    var type = getType(ctx, field);
     var code = '    if (obj.' + field.name;
 
-    if (!field.repeated) {
+    if (!field.repeated && (!type || !type._proto.fields)) {
         if (def === undefined || def) {
-            code += ' !== undefined';
+            code += ' != undefined';
         }
 
         if (def) {

--- a/compile.js
+++ b/compile.js
@@ -60,7 +60,9 @@ function writeMessage(ctx, options) {
             var writeCode = field.repeated && !isPacked(field) ?
                 compileRepeatedWrite(ctx, field, numRepeated++) :
                 compileFieldWrite(ctx, field, field.name);
-            code += '    if (obj.' + field.name + ' !== undefined) ' + writeCode + ';\n';
+            code += '    if (obj.' + field.name + ' !== undefined';
+            code += getDefaultWriteTest(field);
+            code += ') ' + writeCode + ';\n';
         }
         code += '};\n';
     }
@@ -280,6 +282,23 @@ function buildDefaults(ctx, syntax) {
     }
 
     return ctx;
+}
+
+function getDefaultWriteTest(field) {
+    var prefix = ' && obj.' + field.name;
+    var def = field.options.default;
+
+    // Special case for strings to avoid creating unnecessary strings
+    // and comparing.
+    if (def === '') {
+        return prefix + '.length !== 0';
+    }
+
+    if (def !== undefined) {
+        return prefix + ' !== ' + JSON.stringify(def);
+    }
+
+    return '';
 }
 
 function isPacked(field) {

--- a/compile.js
+++ b/compile.js
@@ -12,7 +12,7 @@ function compile(proto) {
 compile.raw = compileRaw;
 
 function compileRaw(proto, options) {
-    var context = buildContext(proto, null);
+    var context = buildDefaults(buildContext(proto, null), proto.syntax);
     return '\'use strict\';\n' + writeContext(context, options || {});
 }
 
@@ -85,9 +85,7 @@ function compileDest(ctx) {
         if (field.repeated && !isPacked(field))
             props.push(field.name + ': []');
 
-        var type = ctx[field.type];
-
-        if (type && type._proto.values && field.options.default !== undefined)
+        if (field.options.default !== undefined)
             props.push(field.name + ': ' + JSON.stringify(field.options.default));
     }
     return '{' + props.join(', ') + '}';
@@ -196,6 +194,61 @@ function buildContext(proto, parent) {
     }
 
     return obj;
+}
+
+function castDefaultValue(field, value) {
+    switch (field.type) {
+    case 'string':   return value;
+    case 'float':
+    case 'double':   return parseFloat(value);
+    case 'bool':     return value === 'true';
+    case 'uint32':
+    case 'uint64':
+    case 'int32':
+    case 'int64':
+    case 'sint32':
+    case 'sint64':
+    case 'fixed32':
+    case 'fixed64':
+    case 'sfixed32':
+    case 'sfixed64': return parseInt(value, 10);
+    default:         throw new Error('Unexpected type: ' + field.type);
+    }
+}
+
+function setDefaultValue(ctx, field, syntax) {
+    var options = field.options;
+    var type = ctx[field.type];
+    var values = type && type._proto.values;
+
+    // Proto3 does not support overriding defaults
+    if (syntax === 3) {
+        delete options.default;
+
+    // Convert enum strings to number
+    } else if (values) {
+        options.default = values[options.default];
+
+    // Defaults are always strings, cast them to appropriate type
+    } else if (options.default !== undefined) {
+        options.default = castDefaultValue(field, options.default);
+    }
+}
+
+function buildDefaults(ctx, syntax) {
+    var proto = ctx._proto;
+
+    for (var i = 0; i < ctx._children.length; i++) {
+        buildDefaults(ctx._children[i], syntax);
+    }
+
+    if (proto.fields) {
+        for (i = 0; i < proto.fields.length; i++) {
+            setDefaultValue(ctx, proto.fields[i], syntax);
+        }
+    }
+
+    return ctx;
 }
 
 function isPacked(field) {

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -19,7 +19,7 @@ test('compiles vector tile proto', function(t) {
     var pbf = new Pbf();
     Tile.write(tile, pbf);
     var buf = pbf.finish();
-    t.equal(buf.length, 197699);
+    t.equal(buf.length, 124946);
 
     t.end();
 });
@@ -59,6 +59,7 @@ test('compiles defaults', function(t) {
     var buf = pbf.finish();
     var data = Envelope.read(new Pbf(buf));
 
+    t.equals(buf.length, 0);
     t.deepEqual(data, {
         type: 1,
         name: 'test',
@@ -80,6 +81,7 @@ test('compiles proto3 ignoring defaults', function(t) {
     var buf = pbf.finish();
     var data = Envelope.read(new Pbf(buf));
 
+    t.equals(buf.length, 0);
     t.deepEqual(data, {
         type: 0,
         name: '',

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -92,3 +92,21 @@ test('compiles proto3 ignoring defaults', function(t) {
 
     t.end();
 });
+
+test('should not write undefined or null values', function(t) {
+    var proto = resolve(path.join(__dirname, './fixtures/embedded_type.proto'));
+    var EmbeddedType = compile(proto).EmbeddedType;
+    var pbf = new Pbf();
+
+    EmbeddedType.write({}, pbf);
+
+    EmbeddedType.write({
+        'sub_field': null
+    }, pbf);
+
+    EmbeddedType.write({
+        value: null
+    });
+
+    t.end();
+});

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -19,7 +19,7 @@ test('compiles vector tile proto', function(t) {
     var pbf = new Pbf();
     Tile.write(tile, pbf);
     var buf = pbf.finish();
-    t.equal(buf.length, 125023);
+    t.equal(buf.length, 197699);
 
     t.end();
 });
@@ -80,7 +80,13 @@ test('compiles proto3 ignoring defaults', function(t) {
     var buf = pbf.finish();
     var data = Envelope.read(new Pbf(buf));
 
-    t.deepEqual(data, {});
+    t.deepEqual(data, {
+        type: 0,
+        name: '',
+        flag: false,
+        weight: 0,
+        id: 0
+    });
 
     t.end();
 });

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -48,3 +48,39 @@ test('compiles packed proto', function(t) {
 
     t.end();
 });
+
+test('compiles defaults', function(t) {
+    var proto = resolve(path.join(__dirname, './fixtures/defaults.proto'));
+    var Envelope = compile(proto).Envelope;
+    var pbf = new Pbf();
+
+    Envelope.write({}, pbf);
+
+    var buf = pbf.finish();
+    var data = Envelope.read(new Pbf(buf));
+
+    t.deepEqual(data, {
+        type: 1,
+        name: 'test',
+        flag: true,
+        weight: 1.5,
+        id: 1
+    });
+
+    t.end();
+});
+
+test('compiles proto3 ignoring defaults', function(t) {
+    var proto = resolve(path.join(__dirname, './fixtures/defaults_proto3.proto'));
+    var Envelope = compile(proto).Envelope;
+    var pbf = new Pbf();
+
+    Envelope.write({}, pbf);
+
+    var buf = pbf.finish();
+    var data = Envelope.read(new Pbf(buf));
+
+    t.deepEqual(data, {});
+
+    t.end();
+});

--- a/test/fixtures/defaults.proto
+++ b/test/fixtures/defaults.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+enum MessageType {
+     UNKNOWN = 0;
+     GREETING = 1;
+}
+
+message Envelope {
+	MessageType type = 1 [default = GREETING];
+	string name = 2 [default = test];
+	bool flag = 3 [default = true];
+	float weight = 4 [default = 1.5];
+	int32 id = 5 [default = 1];
+}

--- a/test/fixtures/defaults_proto3.proto
+++ b/test/fixtures/defaults_proto3.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+enum MessageType {
+     UNKNOWN = 0;
+     GREETING = 1;
+}
+
+message Envelope {
+	MessageType type = 1 [default = GREETING];
+	string name = 2 [default = test];
+	bool flag = 3 [default = true];
+	float weight = 4 [default = 1.5];
+	int32 id = 5 [default = 1];
+}

--- a/test/fixtures/embedded_type.proto
+++ b/test/fixtures/embedded_type.proto
@@ -1,4 +1,4 @@
-// Protocol Version 1
+syntax = "proto2";
 
 package embedded_type;
 
@@ -13,6 +13,7 @@ message EmbeddedType {
         repeated Inner values = 1;
     }
 
+    optional string value = 1 [default = test];
     optional Container sub_field = 4;
     optional Container.Inner sub_sub_field = 5;
 }


### PR DESCRIPTION
Note: This would be a **breaking** change / **major** revision as it drastically affects the way default values are handled.

According to the [protobuf spec](https://developers.google.com/protocol-buffers/docs/proto3#default), when a message is parsed and it does not contain an element the default value for that type is used.

This commit will provide default for each field type when parsing. In addition, similar to other protobuf encoding implementations, when using `proto3` it will omit fields that are equivalent to the default value.

Omitting default values is only safe in `proto3` because the default value can be overriden in `proto2`.