### PR TITLE
Follow-up to default improvements

### DIFF
--- a/bench/vector_tile.js
+++ b/bench/vector_tile.js
@@ -52,7 +52,7 @@ Tile.Value.write = function (obj, pbf) {
 Tile.Feature = {};
 
 Tile.Feature.read = function (pbf, end) {
-    return pbf.readFields(Tile.Feature._readField, {id: 0, type: 0}, end);
+    return pbf.readFields(Tile.Feature._readField, {id: 0, tags: [], type: 0, geometry: []}, end);
 };
 Tile.Feature._readField = function (tag, obj, pbf) {
     if (tag === 1) obj.id = pbf.readVarint();

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -82,18 +82,17 @@ test('compiles proto3 ignoring defaults', function(t) {
     var data = Envelope.read(new Pbf(buf));
 
     t.equals(buf.length, 0);
-    t.deepEqual(data, {
-        type: 0,
-        name: '',
-        flag: false,
-        weight: 0,
-        id: 0
-    });
+
+    t.equals(data.type, 0);
+    t.equals(data.name, '');
+    t.equals(data.flag, false);
+    t.equals(data.weight, 0);
+    t.equals(data.id, 0);
 
     t.end();
 });
 
-test('should not write undefined or null values', function(t) {
+test('does not write undefined or null values', function(t) {
     var proto = resolve(path.join(__dirname, './fixtures/embedded_type.proto'));
     var EmbeddedType = compile(proto).EmbeddedType;
     var pbf = new Pbf();
@@ -107,6 +106,28 @@ test('should not write undefined or null values', function(t) {
     EmbeddedType.write({
         value: null
     });
+
+    t.end();
+});
+
+test('handles all implicit default values', function(t) {
+    var proto = resolve(path.join(__dirname, './fixtures/defaults_implicit.proto'));
+    var Envelope = compile(proto).Envelope;
+    var pbf = new Pbf();
+
+    Envelope.write({}, pbf);
+    var buf = pbf.finish();
+    var data = Envelope.read(new Pbf(buf));
+
+    t.equals(buf.length, 0);
+
+    t.equals(data.type, 0);
+    t.equals(data.name, '');
+    t.equals(data.flag, false);
+    t.equals(data.weight, 0);
+    t.equals(data.id, 0);
+    t.deepEqual(data.tags, []);
+    t.deepEqual(data.numbers, []);
 
     t.end();
 });

--- a/test/fixtures/defaults_implicit.proto
+++ b/test/fixtures/defaults_implicit.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+enum MessageType {
+     UNKNOWN = 0;
+     GREETING = 1;
+}
+
+message Envelope {
+    MessageType type = 1;
+    string name = 2;
+    bool flag = 3;
+    float weight = 4;
+    int32 id = 5;
+    repeated string tags = 6;
+    repeated int32 numbers = 7 [packed = true];
+}


### PR DESCRIPTION
Follow-up to #42 cc @kjvalencik.

- set `[]` default for packed fields too — this is more consistent with default for non-packed repeated fields, and also improves decoding performance (in my bench from 820 to 880) because all properties are now predefined.
- store defaults in a special `_defaults` object rather than overwriting `options`, which makes it easier to understand the code.
- DRY up the code more
- more tests for implicit defaults