### PR TITLE
Avoid writing an unserializable message by defaulting writeVarint to 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ Pbf.prototype = {
     },
 
     writeVarint: function(val) {
-        val = +val;
+        val = +val || 0;
 
         if (val > 0xfffffff) {
             writeBigVarint(val, this);

--- a/test/pbf.test.js
+++ b/test/pbf.test.js
@@ -55,6 +55,25 @@ test('readVarint & writeVarint', function(t) {
     t.end();
 });
 
+test('writeVarint writes 0 for NaN', function(t) {
+    var buf = new Buffer(16);
+    var pbf = new Pbf(buf);
+
+    // Initialize buffer to ensure consistent tests
+    buf.write('0123456789abcdef', 0);
+
+    pbf.writeVarint('not a number');
+    pbf.writeVarint(NaN);
+    pbf.writeVarint(50);
+    pbf.finish();
+
+    t.equal(pbf.readVarint(), 0);
+    t.equal(pbf.readVarint(), 0);
+    t.equal(pbf.readVarint(), 50);
+
+    t.end();
+});
+
 test('readVarint64', function(t) {
     var bytes = [0xc8,0xe8,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x01];
     var buf = new Pbf(new Buffer(bytes));


### PR DESCRIPTION
Resolves https://github.com/mapbox/pbf/issues/52