### PR TITLE
Set oneof value to set field name

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -50,7 +50,13 @@ function writeMessage(ctx, options) {
             code += '    ' + (i ? 'else if' : 'if') +
                 ' (tag === ' + field.tag + ') obj.' + field.name +
                 (field.repeated && !isPacked(field) ?
-                    '.push(' + readCode + ')' : ' = ' + readCode) + ';\n';
+                    '.push(' + readCode + ')' : ' = ' + readCode);
+
+            if (field.oneof) {
+                code += ', obj.' + field.oneof + ' = ' + JSON.stringify(field.name);
+            }
+
+            code += ';\n';
         }
         code += '};\n';
     }
@@ -82,12 +88,13 @@ function compileExport(ctx, options) {
 }
 
 function compileDest(ctx) {
-    var props = [];
+    var props = {};
     for (var i = 0; i < ctx._proto.fields.length; i++) {
         var field = ctx._proto.fields[i];
-        props.push(field.name + ': ' + JSON.stringify(ctx._defaults[field.name]));
+        props[field.name + ': ' + JSON.stringify(ctx._defaults[field.name])] = true;
+        if (field.oneof) props[field.oneof + ': null'] = true;
     }
-    return '{' + props.join(', ') + '}';
+    return '{' + Object.keys(props).join(', ') + '}';
 }
 
 function getType(ctx, field) {

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -133,3 +133,26 @@ test('handles all implicit default values', function(t) {
 
     t.end();
 });
+
+test('sets oneof field name', function(t) {
+    var proto = resolve(path.join(__dirname, './fixtures/oneof.proto'));
+    var Envelope = compile(proto).Envelope;
+    var pbf = new Pbf();
+
+    Envelope.write({}, pbf);
+    var data = Envelope.read(new Pbf(pbf.finish()));
+
+    t.equals(data.value, null);
+    t.equals(data.id, 0);
+
+    pbf = new Pbf();
+    Envelope.write({
+        float: 1.5
+    }, pbf);
+    data = Envelope.read(new Pbf(pbf.finish()));
+
+    t.equals(data.value, 'float');
+    t.equals(data[data.value], 1.5);
+
+    t.end();
+});

--- a/test/fixtures/oneof.proto
+++ b/test/fixtures/oneof.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+message Envelope {
+    int32 id = 1;
+    oneof value {
+        int32 int = 2;
+        float float = 3;
+        string string = 4;
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/mapbox/pbf/issues/51

Previous generated code:

```js
Envelope.read = function (pbf, end) {
    return pbf.readFields(Envelope._readField, {id: 0, int: 0, float: 0, string: ""}, end);
};
Envelope._readField = function (tag, obj, pbf) {
    if (tag === 1) obj.id = pbf.readVarint();
    else if (tag === 2) obj.int = pbf.readVarint();
    else if (tag === 3) obj.float = pbf.readFloat();
    else if (tag === 4) obj.string = pbf.readString();
};
```

New generated code:

```js
Envelope.read = function (pbf, end) {
    return pbf.readFields(Envelope._readField, {id: 0, int: 0, float: 0, string: ""}, end);
};
Envelope._readField = function (tag, obj, pbf) {
    if (tag === 1) obj.id = pbf.readVarint();
    else if (tag === 2) obj.int = pbf.readVarint(), obj.value = "int";
    else if (tag === 3) obj.float = pbf.readFloat(), obj.value = "float";
    else if (tag === 4) obj.string = pbf.readString(), obj.value = "string";
};

```