### PR TITLE
Add a real world tiles bench

### DIFF
--- a/bench/bench-tiles.js
+++ b/bench/bench-tiles.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var runStats = require('tile-stats-runner');
+var Tile = require('./vector_tile').Tile;
+var Pbf = require('../');
+
+var ids = 'mapbox.mapbox-streets-v7';
+var token = 'pk.eyJ1IjoicmVkdWNlciIsImEiOiJrS3k2czVJIn0.CjwU0V9fO4FAf3ukyV4eqQ';
+var url = 'https://b.tiles.mapbox.com/v4/' + ids + '/{z}/{x}/{y}.vector.pbf?access_token=' + token;
+
+var readTime = 0;
+var writeTime = 0;
+var size = 0;
+var numTiles = 0;
+
+runStats(url, processTile, showStats, {
+    width: 2880,
+    height: 1800,
+    minZoom: 0,
+    maxZoom: 16,
+    center: [-77.032751, 38.912792]
+});
+
+function processTile(body) {
+    size += body.length;
+    numTiles++;
+
+    var now = clock();
+    var tile = Tile.read(new Pbf(body));
+    readTime += clock(now);
+
+    now = clock();
+    var pbf = new Pbf();
+    Tile.write(tile, pbf);
+    var buf = pbf.finish();
+    writeTime += clock(now);
+
+    console.assert(buf);
+}
+
+function showStats() {
+    console.log('%d tiles, %d KB total', numTiles, Math.round(size / 1024));
+    console.log('read time: %dms, or %d MB/s', Math.round(readTime), speed(readTime, size));
+    console.log('write time: %dms, or %d MB/s', Math.round(writeTime), speed(writeTime, size));
+}
+
+function speed(time, size) {
+    return Math.round((size / (1 << 20)) / (time / 1000));
+}
+
+function clock(start) {
+    if (!start) return process.hrtime();
+    var t = process.hrtime(start);
+    return t[0] * 1e3 + t[1] * 1e-6;
+}
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "a low-level, lightweight protocol buffers implementation in JavaScript",
   "main": "index.js",
   "scripts": {
-    "test": "eslint index.js compile.js test/*.js bin/pbf && tap test/*.test.js",
+    "test": "eslint index.js compile.js test/*.js bench/bench-tiles.js bin/pbf && tap test/*.test.js",
     "cov": "tap test/*.test.js --cov --coverage-report=html",
     "build-min": "mkdirp dist && browserify index.js -s Pbf | uglifyjs -c warnings=false -m > dist/pbf.js",
     "build-dev": "mkdirp dist && browserify index.js -d -s Pbf > dist/pbf-dev.js",
@@ -46,6 +46,7 @@
     "mkdirp": "^0.5.1",
     "protocol-buffers": "^3.1.6",
     "tap": "^6.1.1",
+    "tile-stats-runner": "^1.0.0",
     "uglify-js": "^2.6.2"
   },
   "eslintConfig": {


### PR DESCRIPTION
I came to the conclusion that the benchmark in `bench/bench.js` doesn’t really make a lot of sense because V8 is extremely good at optimizing stuff that does the same thing over and over.

So I created a much more representative benchmark that downloads (and caches) 439 sample tiles from Mapbox Streets and runs decoding/encoding on them. Here’s a sample result:

```
439 tiles, 22612 KB total
read time: 405ms, or 54 MB/s
write time: 408ms, or 54 MB/s
```

I ran it on all commits between v2.0.1 and master and actually the most impactful change is the defaults PR. This is fine though — e.g. specifically for VT, you can optimize manually by definding a defaults object and then doing `Object.create(defaults)`. This probably doesn’t make sense for the compiler to do though — the performance is more than great as it is.

cc @kjvalencik 