### PR TITLE
Remove unnecessary readVarint64 method

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,8 @@ pbf.readMessage(readFoo);
 
 Scalar reading methods:
 
-* `readVarint()`
+* `readVarint(isSigned)` (pass `true` if you expect negative varints)
 * `readSVarint()`
-* `readVarint64()` (`readVarint` version that handles negative `int64` values)
 * `readFixed32()`
 * `readFixed64()`
 * `readSFixed32()`
@@ -189,15 +188,15 @@ Scalar reading methods:
 
 Packed reading methods:
 
-* `readPackedVarint()`
-* `readPackedSVarint()`
-* `readPackedFixed32()`
-* `readPackedFixed64()`
-* `readPackedSFixed32()`
-* `readPackedSFixed64()`
-* `readPackedBoolean()`
-* `readPackedFloat()`
-* `readPackedDouble()`
+* `readPackedVarint(arr, isSigned)` (appends read items to `arr`)
+* `readPackedSVarint(arr)`
+* `readPackedFixed32(arr)`
+* `readPackedFixed64(arr)`
+* `readPackedSFixed32(arr)`
+* `readPackedSFixed64(arr)`
+* `readPackedBoolean(arr)`
+* `readPackedFloat(arr)`
+* `readPackedDouble(arr)`
 
 #### Writing
 

--- a/index.js
+++ b/index.js
@@ -16,8 +16,7 @@ Pbf.Bytes   = 2; // length-delimited: string, bytes, embedded messages, packed r
 Pbf.Fixed32 = 5; // 32-bit: float, fixed32, sfixed32
 
 var SHIFT_LEFT_32 = (1 << 16) * (1 << 16),
-    SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32,
-    POW_2_63 = Math.pow(2, 63);
+    SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32;
 
 Pbf.prototype = {
 

--- a/index.js
+++ b/index.js
@@ -97,25 +97,6 @@ Pbf.prototype = {
         return readVarintRemainder(val, isSigned, this);
     },
 
-    readVarint64: function() {
-        var startPos = this.pos,
-            val = this.readVarint();
-
-        if (val < POW_2_63) return val;
-
-        var pos = this.pos - 2;
-        while (this.buf[pos] === 0xff) pos--;
-        if (pos < startPos) pos = startPos;
-
-        val = 0;
-        for (var i = 0; i < pos - startPos + 1; i++) {
-            var b = ~this.buf[startPos + i] & 0x7f;
-            val += i < 4 ? b << i * 7 : b * Math.pow(2, i * 7);
-        }
-
-        return -val - 1;
-    },
-
     readSVarint: function() {
         var num = this.readVarint();
         return num % 2 === 1 ? (num + 1) / -2 : num / 2; // zigzag encoding

--- a/test/pbf.test.js
+++ b/test/pbf.test.js
@@ -79,15 +79,15 @@ test('writeVarint writes 0 for NaN', function(t) {
 test('readVarint64', function(t) {
     var bytes = [0xc8,0xe8,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x01];
     var buf = new Pbf(new Buffer(bytes));
-    t.equal(buf.readVarint64(), -3000);
+    t.equal(buf.readVarint(true), -3000);
 
     bytes = [0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x01];
     buf = new Pbf(new Buffer(bytes));
-    t.equal(buf.readVarint64(), -1);
+    t.equal(buf.readVarint(true), -1);
 
     bytes = [0xc8,0x01];
     buf = new Pbf(new Buffer(bytes));
-    t.equal(buf.readVarint64(), 200);
+    t.equal(buf.readVarint(true), 200);
 
     t.end();
 });


### PR DESCRIPTION
cc @kjvalencik — just realized it’s now unnecessary after your changes. 