### PR TITLE
Respect packed flag in proto3

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -316,7 +316,9 @@ function setPackedOption(ctx, field, syntax) {
     case 'fixed64':
     case 'sfixed32':
     case 'enum':
-    case 'bool':     field.options.packed = 'true'; break;
+    case 'bool':
+        if (field.options.packed !== 'false') field.options.packed = 'true';
+        break;
     default:         delete field.options.packed;
     }
 }

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -61,12 +61,17 @@ test('compiles packed proto3', function(t) {
         value: [300, 400, 500]
     };
     var pbf = new Pbf();
-    NotPacked.write(original, pbf);
-    var buf = pbf.finish();
+    FalsePacked.write(original, pbf);
+    var falsePackedBuf = pbf.finish();
 
-    var decompressed = FalsePacked.read(new Pbf(buf));
-    t.equals(buf.length, 14);
+    pbf = new Pbf();
+    NotPacked.write(original, pbf);
+    var notPackedBuf = pbf.finish();
+
+    var decompressed = NotPacked.read(new Pbf(falsePackedBuf));
     t.deepEqual(original, decompressed);
+    t.equals(notPackedBuf.length, 14);
+    t.ok(falsePackedBuf.length > notPackedBuf.length, 'Did not respect [packed=false]');
 
     t.end();
 });


### PR DESCRIPTION
If a proto file is defined as `proto3`, currently fields will _always_ be packed, even if they are defined as `[packed=false]`.