### PR TITLE
Add protobuf.js to benchmarks

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -2,44 +2,53 @@
 
 var Benchmark = require('benchmark'),
     fs = require('fs'),
-    protobuf = require('protocol-buffers'),
+    path = require('path'),
+    protocolBuffers = require('protocol-buffers'),
+    protobufjs = require('protobufjs'),
     vt = require('./vector_tile'),
-    Pbf = require('../'),
-    readTile = vt.Tile.read,
-    writeTile = vt.Tile.write;
+    Pbf = require('../');
 
-var Tile = protobuf(fs.readFileSync(__dirname + '/vector_tile.proto')).Tile,
-    data = fs.readFileSync(__dirname + '/../test/fixtures/12665.vector.pbf'),
-    suite = new Benchmark.Suite();
+var pbfReadTile = vt.Tile.read,
+    pbfWriteTile = vt.Tile.write,
+    data = fs.readFileSync(path.resolve(__dirname, '../test/fixtures/12665.vector.pbf')),
+    suite = new Benchmark.Suite(),
+    ProtocolBuffersTile = protocolBuffers(fs.readFileSync(path.resolve(__dirname, 'vector_tile.proto'))).Tile,
+    ProtobufjsTile = protobufjs.loadSync(path.resolve(__dirname, 'vector_tile.proto'))
+        .lookup('vector_tile.Tile');
 
-var tile = readTile(new Pbf(data)),
-    tileJSON = JSON.stringify(tile),
-    tile2 = Tile.decode(data);
-
-writeTile(tile, new Pbf());
+var pbfTile = pbfReadTile(new Pbf(data)),
+    tileJSON = JSON.stringify(pbfTile),
+    protocolBuffersTile = ProtocolBuffersTile.decode(data),
+    protobufjsTile = ProtobufjsTile.decode(data);
 
 suite
-.add('decode vector tile with pbf', function() {
-    readTile(new Pbf(data));
-})
-.add('encode vector tile with pbf', function() {
-    var pbf = new Pbf();
-    writeTile(tile, pbf);
-    pbf.finish();
-})
-.add('decode vector tile with protocol-buffers', function() {
-    Tile.decode(data);
-})
-.add('encode vector tile with protocol-buffers', function() {
-    Tile.encode(tile2);
-})
-.add('JSON.parse vector tile', function() {
-    JSON.parse(tileJSON);
-})
-.add('JSON.stringify vector tile', function() {
-    JSON.stringify(tile);
-})
-.on('cycle', function(event) {
-    console.log(String(event.target));
-})
-.run();
+    .add('decode vector tile with pbf', function() {
+        pbfReadTile(new Pbf(data));
+    })
+    .add('encode vector tile with pbf', function() {
+        var pbf = new Pbf();
+        pbfWriteTile(pbfTile, pbf);
+        pbf.finish();
+    })
+    .add('decode vector tile with protocol-buffers', function() {
+        ProtocolBuffersTile.decode(data);
+    })
+    .add('encode vector tile with protocol-buffers', function() {
+        ProtocolBuffersTile.encode(protocolBuffersTile);
+    })
+    .add('decode vector tile with protobuf.js', function() {
+        ProtobufjsTile.decode(data);
+    })
+    .add('encode vector tile with protobuf.js', function() {
+        ProtobufjsTile.encode(protobufjsTile);
+    })
+    .add('JSON.parse vector tile', function() {
+        JSON.parse(tileJSON);
+    })
+    .add('JSON.stringify vector tile', function() {
+        JSON.stringify(pbfTile);
+    })
+    .on('cycle', function(event) {
+        console.log(String(event.target));
+    })
+    .run();

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "a low-level, lightweight protocol buffers implementation in JavaScript",
   "main": "index.js",
   "scripts": {
+    "bench": "node bench/bench.js",
     "test": "eslint index.js compile.js test/*.js bench/bench-tiles.js bin/pbf && tap test/*.test.js",
     "cov": "tap test/*.test.js --cov --coverage-report=html",
     "build-min": "mkdirp dist && browserify index.js -s Pbf | uglifyjs -c warnings=false -m > dist/pbf.js",
@@ -44,6 +45,7 @@
     "eslint": "^4.2.0",
     "eslint-config-mourner": "^2.0.1",
     "mkdirp": "^0.5.1",
+    "protobufjs": "^6.8.6",
     "protocol-buffers": "^3.1.6",
     "tap": "^10.7.0",
     "tile-stats-runner": "^1.0.0",


### PR DESCRIPTION
I was doing some comparisons on various protocol buffer libraries for JS, and I thought others might benefit from a benchmark comparing pbf and [protobuf.js](https://github.com/dcodeIO/protobuf.js). Pbf seems faster on this data set at encoding, and is on par for decoding. Cheers!