### PR TITLE
Fix a corruption when raw message > 0x10000000 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ The resulting code is clean and simple, so feel free to customize it.
 
 ## Changelog
 
+#### 3.1.1 (March 8, 2019)
+
+- Fixed an off-by-one data corruption bug when writing a message larger than 0x10000000 bytes.
+
 #### 3.1.0 (Sep 27, 2017)
 
 - Added support for Protocol Buffer 3 [maps](https://developers.google.com/protocol-buffers/docs/proto3#maps) to proto compiler.

--- a/index.js
+++ b/index.js
@@ -467,7 +467,7 @@ function makeRoomForExtraLength(startPos, len, pbf) {
     var extraLen =
         len <= 0x3fff ? 1 :
         len <= 0x1fffff ? 2 :
-        len <= 0xfffffff ? 3 : Math.ceil(Math.log(len) / (Math.LN2 * 7));
+        len <= 0xfffffff ? 3 : Math.floor(Math.log(len) / (Math.LN2 * 7));
 
     // if 1 byte isn't enough for encoding message length, shift the data to the right
     pbf.realloc(extraLen);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbf",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "a low-level, lightweight protocol buffers implementation in JavaScript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fixes a data corruption bug when writing a message that exceeds
0x10000000 bytes in size. The varint-encoded size in the beginning of
the message includes an extra byte.

Add a test for this condition.