### PR TITLE
Fix broken tests

### DIFF
--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -126,7 +126,10 @@ test('compiles defaults', function(t) {
 
     t.equals(buf.length, 0);
     t.deepEqual(data, {
-        type: 1,
+        type: {
+            options: {},
+            value: 1
+        },
         name: 'test',
         flag: true,
         weight: 1.5,

--- a/test/fixtures/packed.proto
+++ b/test/fixtures/packed.proto
@@ -4,20 +4,15 @@ package vector_tile;
 
 option optimize_for = LITE_RUNTIME;
 
-enum MessageType {
-     UNKNOWN = 0;
-     GREETING = 1;
-}
-
 message NotPacked {
   repeated int32 value = 1;
-  repeated MessageType types = 2;
+  repeated int32 types = 2;
 }
 message FalsePacked {
   repeated int32 value = 1 [packed=false];
-  repeated MessageType types = 2 [packed=false];
+  repeated int32 types = 2 [packed=false];
 }
 message Packed {
   repeated int32 value = 1 [packed=true];
-  repeated MessageType types = 2 [packed=true];
+  repeated int32 types = 2 [packed=true];
 }


### PR DESCRIPTION
One of the transitive dependencies (protocol-buffers-schema) got
upgraded, causing some of the compile tests to break, most notably
with this message:

    Fields of type MessageType cannot be declared [packed=true]. Only
    repeated fields of primitive numeric types (types which use the
    varint, 32-bit, or 64-bit wire types) can be declared "packed". See
    https://developers.google.com/protocol-buffers/docs/encoding#optional

Remove the `MessageType` enum and use `int32` in its place.

The new version of `protocol-buffers-schema` also changed how enums are
represented in json, breaking another test.