### PR TITLE
Fix #98: keep `exports` with `--no-read` option

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -37,9 +37,11 @@ function writeMessage(ctx, options) {
 
     var code = '\n// ' + name + ' ========================================\n\n';
 
-    if (!options.noRead) {
+    if (!options.noRead || !options.noWrite) {
         code += compileExport(ctx, options) + ' {};\n\n';
+    }
 
+    if (!options.noRead) {
         code += name + '.read = function (pbf, end) {\n';
         code += '    return pbf.readFields(' + name + '._readField, ' + compileDest(ctx) + ', end);\n';
         code += '};\n';


### PR DESCRIPTION
With this patch, `exports` will be added to result code, even if `--no-read` option is used.

Fixes #98