### PR TITLE
add dash in utf-8

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var SHIFT_LEFT_32 = (1 << 16) * (1 << 16),
 // Threshold chosen based on both benchmarking and knowledge about browser string
 // data structures (which currently switch structure types at 12 bytes or more)
 var TEXT_DECODER_MIN_LENGTH = 12;
-var utf8TextDecoder = typeof TextDecoder === 'undefined' ? null : new TextDecoder('utf8');
+var utf8TextDecoder = typeof TextDecoder === 'undefined' ? null : new TextDecoder('utf-8');
 
 Pbf.prototype = {
 


### PR DESCRIPTION
The default for TextDecoder is the format 'utf-8'. In my project I'm also using the library @auth0/auth0-spa-js, which loads the polyfill fast-text-encoding for TextDecoder. This polyfilled version will throw an error if it gets passed 'utf8'. This causes my app to crash on Edge.

alternatives:
- remove the argument, it'll default to utf-8.
- wrap the initializer in a try/catch