### PR TITLE
added support for js_type at compile time

### DIFF
--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -252,6 +252,38 @@ test('sets oneof field name', function(t) {
     t.end();
 });
 
+test('handles jstype=JS_STRING', function(t) {
+    var proto = resolve(path.join(__dirname, './fixtures/type_string.proto'));
+    var TypeString = compile(proto).TypeString;
+    var TypeNotString = compile(proto).TypeNotString;
+    var pbf = new Pbf();
+
+    TypeString.write({
+        int: '-5',
+        long: '10000',
+        boolVal: true,
+        float: '12',
+    }, pbf);
+
+    var buf = pbf.finish();
+    var data = TypeString.read(new Pbf(buf));
+
+    t.equals(data.int, '-5');
+    t.equals(data.long, '10000');
+    t.equals(data.boolVal, true);
+    t.equals(data.float, '12');
+    t.equals(data.default_implicit, '0');
+    t.equals(data.default_explicit, '42');
+
+    data = TypeNotString.read(new Pbf(buf));
+    t.equals(data.int, -5);
+    t.equals(data.long, 10000);
+    t.equals(data.boolVal, true);
+    t.equals(data.float, 12);
+
+    t.end();
+});
+
 test('handles negative varint', function(t) {
     var proto = resolve(path.join(__dirname, './fixtures/varint.proto'));
     var Envelope = compile(proto).Envelope;

--- a/test/fixtures/type_string.proto
+++ b/test/fixtures/type_string.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+message TypeString {
+	int32 int = 1 [jstype = JS_STRING];
+	int64 long = 2 [jstype = JS_STRING];
+	bool boolVal = 3 [jstype = JS_STRING];
+	float float = 4 [jstype = JS_STRING];
+	int32 default_implicit = 5 [jstype = JS_STRING];
+	int32 default_explicit = 6 [jstype = JS_STRING, default = 42];
+}
+
+message TypeNotString {
+	int32 int = 1;
+	int64 long = 2;
+	bool boolVal = 3;
+	float float = 4;
+}


### PR DESCRIPTION
This adds support for the jstype option.

When a field (integer or floating number) has the jstype option set to JS_STRING, it will be converted to and from string.

All the changes happen at compile time, so it should not break any application, nor increase the size of the application.