### PR TITLE
v5: split into `PbfReader`/`PbfWriter`; 25% faster

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024, Mapbox
+Copyright (c) 2026, Mapbox
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -7,17 +7,20 @@ A low-level, fast, ultra-lightweight (3KB gzipped) JavaScript library for decodi
 
 ## Performance
 
-This library is extremely fast — much faster than native `JSON.parse`/`JSON.stringify`
-and the [protocol-buffers](https://github.com/mafintosh/protocol-buffers) module.
-Here's a result from running a real-world benchmark on Node v6.5
-(decoding and encoding a sample of 439 vector tiles, 22.6 MB total):
+This library is fast — competitive with or faster than other JS protobuf implementations,
+and orders of magnitude smaller. Here's a result from a real-world benchmark on Node v26
+(decoding and encoding 439 Mapbox vector tiles, 37.5 MB total; the equivalent JSON is 136 MB):
 
-- **pbf** decode: 387ms, or 57 MB/s
-- **pbf** encode: 396ms, or 56 MB/s
-- **protocol-buffers** decode: 837ms, or 26 MB/s
-- **protocol-buffers** encode: 4197ms, or 5 MB/s
-- **JSON.parse**: 1540ms, or 15 MB/s (parsing an equivalent 77.5 MB JSON file)
-- **JSON.stringify**: 607ms, or 49 MB/s
+|                  | decode            | encode            |
+|------------------|-------------------|-------------------|
+| **pbf**          | 236ms, 159 MB/s   | 184ms, 204 MB/s   |
+| protocol-buffers | 293ms, 128 MB/s   | 618ms,  61 MB/s   |
+| protobuf.js      | 220ms, 170 MB/s   | 504ms,  74 MB/s   |
+| JSON             | 484ms, 281 MB/s   | 263ms, 516 MB/s   |
+
+`JSON` throughput is measured against the 136 MB JSON payload, not the 37.5 MB pbf payload —
+on the same data, pbf is ~2× faster to decode and ~2.5× faster to encode, and produces output
+roughly a quarter the size. See `bench/bench-tiles.js`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ $ pbf example.proto > example.js
 Then read and write objects using the module like this:
 
 ```js
-import Pbf from 'pbf';
+import {PbfReader, PbfWriter} from 'pbf';
 import {readExample, writeExample} from './example.js';
 
 // read
-var obj = readExample(new Pbf(buffer));
+const obj = readExample(new PbfReader(buffer));
 
 // write
-const pbf = new Pbf();
+const pbf = new PbfWriter();
 writeExample(obj, pbf);
 const buffer = pbf.finish();
 ```
@@ -58,7 +58,7 @@ const {readExample, writeExample} = compile(proto);
 #### Custom Reading
 
 ```js
-var data = new Pbf(buffer).readFields(readData, {});
+const data = new PbfReader(buffer).readFields(readData, {});
 
 function readData(tag, data, pbf) {
     if (tag === 1) data.name = pbf.readString();
@@ -74,9 +74,9 @@ function readLayer(tag, layer, pbf) {
 #### Custom Writing
 
 ```js
-var pbf = new Pbf();
+const pbf = new PbfWriter();
 writeData(data, pbf);
-var buffer = pbf.finish();
+const buffer = pbf.finish();
 
 function writeData(data, pbf) {
     pbf.writeStringField(1, data.name);
@@ -94,18 +94,18 @@ function writeLayer(layer, pbf) {
 Install using NPM with `npm install pbf`, then import as a module:
 
 ```js
-import Pbf from 'pbf';
+import {PbfReader, PbfWriter} from 'pbf';
 ```
 
 Or use as a module directly in the browser with [jsDelivr](https://www.jsdelivr.com/esm):
 
 ```html
 <script type="module">
-    import Pbf from 'https://cdn.jsdelivr.net/npm/pbf/+esm';
+    import {PbfReader, PbfWriter} from 'https://cdn.jsdelivr.net/npm/pbf/+esm';
 </script>
 ```
 
-Alternatively, there's a browser bundle with a `Pbf` global variable:
+Alternatively, there's a browser bundle exposing a `Pbf` global with `PbfReader` and `PbfWriter` properties:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/pbf"></script>
@@ -113,17 +113,19 @@ Alternatively, there's a browser bundle with a `Pbf` global variable:
 
 ## API
 
-Create a `Pbf` object, optionally given a `Buffer` or `Uint8Array` as input data:
+The library exposes two classes: `PbfReader` for decoding and `PbfWriter` for encoding. Splitting them lets bundlers tree-shake the half you don't use.
+
+Create a `PbfReader` from a `Buffer` or `Uint8Array`:
 
 ```js
 // parse a pbf file from disk in Node
-const pbf = new Pbf(fs.readFileSync('data.pbf'));
+const pbf = new PbfReader(fs.readFileSync('data.pbf'));
 
 // parse a pbf file in a browser after an ajax request with responseType="arraybuffer"
-const pbf = new Pbf(new Uint8Array(xhr.response));
+const pbf = new PbfReader(new Uint8Array(xhr.response));
 ```
 
-`Pbf` object properties:
+Both classes expose the following properties:
 
 ```js
 pbf.length; // length of the underlying buffer
@@ -143,7 +145,7 @@ pbf.readFields((tag) => {
 ```
 
 It optionally accepts an object that will be passed to the reading function for easier construction of decoded data,
-and also passes the `Pbf` object as a third argument:
+and also passes the `PbfReader` object as a third argument:
 
 ```js
 const result = pbf.readFields(readField, {})
@@ -204,6 +206,12 @@ Packed reading methods:
 * `readPackedDouble(arr)`
 
 #### Writing
+
+Create a `PbfWriter` (optionally with a pre-allocated `Buffer` or `Uint8Array`):
+
+```js
+const pbf = new PbfWriter();
+```
 
 Write values:
 
@@ -287,7 +295,7 @@ The `--legacy` switch makes it generate a CommonJS module instead of ESM.
 `Pbf` will generate `read<Identifier>` and `write<Identifier>` functions for every message in the schema. For nested messages, their names will be concatenated — e.g. `Message` inside `Test` will produce `readTestMessage` and `writeTestMessage` functions.
 
 
-* `read(pbf)` - decodes an object from the given `Pbf` instance.
-* `write(obj, pbf)` - encodes an object into the given `Pbf` instance (usually empty).
+* `read(pbf)` - decodes an object from the given `PbfReader` instance.
+* `write(obj, pbf)` - encodes an object into the given `PbfWriter` instance (usually empty).
 
 The resulting code is clean and simple, so it's meant to be customized.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ and orders of magnitude smaller. Here's a result from a real-world benchmark on 
 
 |                  | decode            | encode            |
 |------------------|-------------------|-------------------|
-| **pbf**          | 236ms, 159 MB/s   | 184ms, 204 MB/s   |
-| protocol-buffers | 293ms, 128 MB/s   | 618ms,  61 MB/s   |
-| protobuf.js      | 220ms, 170 MB/s   | 504ms,  74 MB/s   |
-| JSON             | 484ms, 281 MB/s   | 263ms, 516 MB/s   |
+| **pbf**          | 200ms, 187 MB/s   | 188ms, 200 MB/s   |
+| protocol-buffers | 297ms, 126 MB/s   | 620ms,  60 MB/s   |
+| protobuf.js      | 226ms, 169 MB/s   | 510ms,  74 MB/s   |
+| JSON             | 488ms, 278 MB/s   | 267ms, 509 MB/s   |
 
 `JSON` throughput is measured against the 136 MB JSON payload, not the 37.5 MB pbf payload —
 on the same data, pbf is ~2× faster to decode and ~2.5× faster to encode, and produces output

--- a/bench/bench-tiles.js
+++ b/bench/bench-tiles.js
@@ -3,21 +3,44 @@ import {createHash} from 'crypto';
 import {mkdirSync, existsSync, readFileSync, writeFileSync} from 'fs';
 import {join, dirname} from 'path';
 import {fileURLToPath} from 'url';
+import protocolBuffers from 'protocol-buffers';
+import protobufjs from 'protobufjs';
 import {readTile, writeTile} from '../test/fixtures/vector_tile.js';
 import {PbfReader, PbfWriter} from '../index.js';
 
-const token = process.env.ACCESS_TOKEN;
-if (!token) throw new Error('Missing ACCESS_TOKEN environment variable (Mapbox access token).');
+const vtProtoUrl = new URL('../test/fixtures/vector_tile.proto', import.meta.url);
+const ProtocolBuffersTile = protocolBuffers(readFileSync(vtProtoUrl)).Tile;
+const ProtobufjsTile = protobufjs.loadSync(fileURLToPath(vtProtoUrl)).lookup('vector_tile.Tile');
 
 const tilesetId = 'mapbox.mapbox-streets-v8';
-const url = `https://api.mapbox.com/v4/${tilesetId}/{z}/{x}/{y}.mvt?access_token=${token}`;
+const urlTemplate = `https://api.mapbox.com/v4/${tilesetId}/{z}/{x}/{y}.mvt?access_token={token}`;
 
-let readTime = 0;
-let writeTime = 0;
+const libs = {
+    pbf: {
+        decode: body => readTile(new PbfReader(body)),
+        encode: (tile) => { const pbf = new PbfWriter(); writeTile(tile, pbf); return pbf.finish(); }
+    },
+    'protocol-buffers': {
+        decode: body => ProtocolBuffersTile.decode(body),
+        encode: tile => ProtocolBuffersTile.encode(tile)
+    },
+    'protobuf.js': {
+        decode: body => ProtobufjsTile.decode(body),
+        encode: tile => ProtobufjsTile.encode(tile).finish()
+    },
+    JSON: {
+        decode: body => JSON.parse(body),
+        encode: tile => JSON.stringify(tile)
+    }
+};
+
+const stats = {};
+for (const name of Object.keys(libs)) stats[name] = {read: 0, write: 0};
 let size = 0;
+let jsonSize = 0;
 let numTiles = 0;
 
-await runStats(url, processTile, showStats, {
+await runStats(urlTemplate, processTile, showStats, {
     width: 2880,
     height: 1800,
     minZoom: 0,
@@ -30,23 +53,47 @@ function processTile(body) {
     size += body.length;
     numTiles++;
 
-    let now = clock();
+    // pre-decode once with pbf to get a tile object usable as input for encoders
     const tile = readTile(new PbfReader(body));
-    readTime += clock(now);
+    const tileJSON = JSON.stringify(tile);
+    jsonSize += tileJSON.length;
+    const pbInput = ProtocolBuffersTile.decode(body);
+    const pbjsInput = ProtobufjsTile.decode(body);
 
-    now = clock();
-    const pbf = new PbfWriter();
-    writeTile(tile, pbf);
-    const buf = pbf.finish();
-    writeTime += clock(now);
+    const inputs = {
+        pbf: body,
+        'protocol-buffers': body,
+        'protobuf.js': body,
+        JSON: tileJSON
+    };
+    const encodeInputs = {
+        pbf: tile,
+        'protocol-buffers': pbInput,
+        'protobuf.js': pbjsInput,
+        JSON: tile
+    };
 
-    console.assert(buf);
+    for (const name of Object.keys(libs)) {
+        let now = clock();
+        libs[name].decode(inputs[name]);
+        stats[name].read += clock(now);
+
+        now = clock();
+        libs[name].encode(encodeInputs[name]);
+        stats[name].write += clock(now);
+    }
 }
 
 function showStats() {
-    console.log('%d tiles, %d KB total', numTiles, Math.round(size / 1024));
-    console.log('read time: %dms, or %d MB/s', Math.round(readTime), speed(readTime, size));
-    console.log('write time: %dms, or %d MB/s', Math.round(writeTime), speed(writeTime, size));
+    console.log('%d tiles, %d KB pbf / %d KB JSON', numTiles, Math.round(size / 1024), Math.round(jsonSize / 1024));
+    for (const name of Object.keys(libs)) {
+        const inSize = name === 'JSON' ? jsonSize : size;
+        const s = stats[name];
+        console.log('%s decode: %dms, %d MB/s   encode: %dms, %d MB/s',
+            name.padEnd(18),
+            Math.round(s.read), speed(s.read, inSize),
+            Math.round(s.write), speed(s.write, inSize));
+    }
 }
 
 function speed(time, size) {
@@ -61,7 +108,8 @@ function clock(start) {
 
 async function runStats(urlTemplate, onTile, onDone, options) {
     const cacheRoot = join(dirname(fileURLToPath(import.meta.url)), 'tile-cache');
-    const cachePath = join(cacheRoot, createHash('sha1').update(urlTemplate).digest('hex').slice(0, 8));
+    const cacheKey = urlTemplate.replace(/access_token=[^&]*/, '');
+    const cachePath = join(cacheRoot, createHash('sha1').update(cacheKey).digest('hex').slice(0, 8));
     mkdirSync(cachePath, {recursive: true});
 
     const tilePromises = [];
@@ -97,10 +145,14 @@ async function loadTile(z, x, y, urlTemplate, cachePath) {
         return readFileSync(tilePath);
     }
 
+    const token = process.env.MAPBOX_ACCESS_TOKEN;
+    if (!token) throw new Error('Missing MAPBOX_ACCESS_TOKEN environment variable.');
+
     const tileUrl = urlTemplate
         .replace('{x}', x)
         .replace('{y}', y)
-        .replace('{z}', z);
+        .replace('{z}', z)
+        .replace('{token}', token);
 
     const response = await fetch(tileUrl);
 

--- a/bench/bench-tiles.js
+++ b/bench/bench-tiles.js
@@ -4,7 +4,7 @@ import {mkdirSync, existsSync, readFileSync, writeFileSync} from 'fs';
 import {join, dirname} from 'path';
 import {fileURLToPath} from 'url';
 import {readTile, writeTile} from '../test/fixtures/vector_tile.js';
-import Pbf from '../index.js';
+import {PbfReader, PbfWriter} from '../index.js';
 
 const token = process.env.ACCESS_TOKEN;
 if (!token) throw new Error('Missing ACCESS_TOKEN environment variable (Mapbox access token).');
@@ -31,11 +31,11 @@ function processTile(body) {
     numTiles++;
 
     let now = clock();
-    const tile = readTile(new Pbf(body));
+    const tile = readTile(new PbfReader(body));
     readTime += clock(now);
 
     now = clock();
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
     writeTile(tile, pbf);
     const buf = pbf.finish();
     writeTime += clock(now);

--- a/bench/bench.html
+++ b/bench/bench.html
@@ -6,14 +6,14 @@
 </head>
 <body>
     <script type="module">
-        import Pbf from '../index.js';
-        import {readTile, writeTile} from './vector_tile.js';
+        import {PbfReader, PbfWriter} from '../index.js';
+        import {readTile, writeTile} from '../test/fixtures/vector_tile.js';
 
         function read(data) {
-            return readTile(new Pbf(data));
+            return readTile(new PbfReader(data));
         }
         function write(tile) {
-            var pbf = new Pbf();
+            const pbf = new PbfWriter();
             writeTile(tile, pbf);
             return pbf.finish();
         }

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -6,47 +6,47 @@ import protocolBuffers from 'protocol-buffers';
 import protobufjs from 'protobufjs';
 
 import {readTile, writeTile} from '../test/fixtures/vector_tile.js';
-import Pbf from '../index.js';
+import {PbfReader, PbfWriter} from '../index.js';
 
-var data = fs.readFileSync(new URL('../test/fixtures/12665.vector.pbf', import.meta.url)),
+const data = fs.readFileSync(new URL('../test/fixtures/12665.vector.pbf', import.meta.url)),
     suite = new Benchmark.Suite(),
     vtProtoUrl = new URL('../test/fixtures/vector_tile.proto', import.meta.url),
     ProtocolBuffersTile = protocolBuffers(fs.readFileSync(vtProtoUrl)).Tile,
     ProtobufjsTile = protobufjs.loadSync(fileURLToPath(vtProtoUrl)).lookup('vector_tile.Tile');
 
-var pbfTile = readTile(new Pbf(data)),
+const pbfTile = readTile(new PbfReader(data)),
     tileJSON = JSON.stringify(pbfTile),
     protocolBuffersTile = ProtocolBuffersTile.decode(data),
     protobufjsTile = ProtobufjsTile.decode(data);
 
 suite
-    .add('decode vector tile with pbf', function() {
-        readTile(new Pbf(data));
+    .add('decode vector tile with pbf', () => {
+        readTile(new PbfReader(data));
     })
-    .add('encode vector tile with pbf', function() {
-        var pbf = new Pbf();
+    .add('encode vector tile with pbf', () => {
+        const pbf = new PbfWriter();
         writeTile(pbfTile, pbf);
         pbf.finish();
     })
-    .add('decode vector tile with protocol-buffers', function() {
+    .add('decode vector tile with protocol-buffers', () => {
         ProtocolBuffersTile.decode(data);
     })
-    .add('encode vector tile with protocol-buffers', function() {
+    .add('encode vector tile with protocol-buffers', () => {
         ProtocolBuffersTile.encode(protocolBuffersTile);
     })
-    .add('decode vector tile with protobuf.js', function() {
+    .add('decode vector tile with protobuf.js', () => {
         ProtobufjsTile.decode(data);
     })
-    .add('encode vector tile with protobuf.js', function() {
+    .add('encode vector tile with protobuf.js', () => {
         ProtobufjsTile.encode(protobufjsTile);
     })
-    .add('JSON.parse vector tile', function() {
+    .add('JSON.parse vector tile', () => {
         JSON.parse(tileJSON);
     })
-    .add('JSON.stringify vector tile', function() {
+    .add('JSON.stringify vector tile', () => {
         JSON.stringify(pbfTile);
     })
-    .on('cycle', function(event) {
+    .on('cycle', (event) => {
         console.log(String(event.target));
     })
     .run();

--- a/compile.js
+++ b/compile.js
@@ -18,9 +18,7 @@ function writeContext(ctx, options) {
     if (ctx._proto.fields) code += writeMessage(ctx, options);
     if (ctx._proto.values) code += writeEnum(ctx, options);
 
-    for (let i = 0; i < ctx._children.length; i++) {
-        code += writeContext(ctx._children[i], options);
-    }
+    for (const child of ctx._children) code += writeContext(child, options);
     return code;
 }
 
@@ -39,42 +37,32 @@ function writeMessage(ctx, options) {
         code += `        const tag = pbf.readVarint(), field = tag >>> 3${hasPackable ? '; pbf.type = tag & 7' : ''};\n`;
 
         for (let i = 0; i < fields.length; i++) {
-            const field = fields[i];
-            const {type, name, repeated, oneof} = field;
-            const packable = willSupportPacked(ctx, field);
-
-            const wrap = body => (type === 'map' || oneof ? `{ ${body}; }` : `${body};`);
-            const oneofTail = oneof ? `; obj.${oneof} = ${JSON.stringify(name)}` : '';
-
-            const scalarRead = compileScalarFieldRead(ctx, field);
-            const body =
-                repeated && packable ? compilePackedRead(ctx, field) :
-                type === 'map' ? compileMapRead(scalarRead, name) :
-                repeated ? `obj.${name}.push(${scalarRead})` :
-                `obj.${name} = ${scalarRead}`;
-
-            code += `        ${i ? 'else ' : ''}if (field === ${field.tag}) ${wrap(body + oneofTail)}\n`;
+            code += `        ${i ? 'else ' : ''}if (field === ${fields[i].tag}) ${compileFieldRead(ctx, fields[i])}\n`;
         }
         code += `        ${fields.length ? 'else ' : ''}pbf.skip(tag);\n`;
-        code += `    }
-    return obj;
-}
-`;
+        code += '    }\n    return obj;\n}\n';
     }
 
     if (!options.noWrite) {
         const writeName = `write${ctx._name}`;
         code += `${writeFunctionExport(options, writeName)}function ${writeName}(obj, pbf) {\n`;
-        for (const field of fields) {
-            const writeCode =
-                field.repeated && !isPacked(field) ? compileRepeatedWrite(ctx, field) :
-                field.type === 'map' ? compileMapWrite(ctx, field) : compileFieldWrite(ctx, field, `obj.${field.name}`);
-            code += getDefaultWriteTest(ctx, field);
-            code += `${writeCode};\n`;
-        }
+        for (const field of fields) code += compileFieldWriteLine(ctx, field);
         code += '}\n';
     }
     return code;
+}
+
+function compileFieldWriteLine(ctx, field) {
+    const v = `obj.${field.name}`;
+    let body;
+    if (field.repeated && !isPacked(field)) {
+        body = `for (const item of ${v}) ${compileFieldWrite(ctx, field, 'item')}`;
+    } else if (field.type === 'map') {
+        body = `for (const key of Object.keys(${v})) ${compileFieldWrite(ctx, field, `{key, value: ${v}[key]}`)}`;
+    } else {
+        body = compileFieldWrite(ctx, field, v);
+    }
+    return `${getDefaultWriteTest(ctx, field)}${body};\n`;
 }
 
 function writeFunctionExport({legacy}, name) {
@@ -83,10 +71,7 @@ function writeFunctionExport({legacy}, name) {
 
 function getEnumValues(ctx) {
     const enums = {};
-    const ids = Object.keys(ctx._proto.values);
-    for (let i = 0; i < ids.length; i++) {
-        enums[ids[i]] = ctx._proto.values[ids[i]].value;
-    }
+    for (const [name, {value}] of Object.entries(ctx._proto.values)) enums[name] = value;
     return enums;
 }
 
@@ -100,7 +85,7 @@ function compileDest(ctx) {
     const props = new Set();
     for (const {name, oneof} of ctx._proto.fields) {
         props.add(`${name}: ${JSON.stringify(ctx._defaults[name])}`);
-        if (oneof) props.add(`${oneof  }: undefined`);
+        if (oneof) props.add(`${oneof}: undefined`);
     }
     return `{${[...props].join(', ')}}`;
 }
@@ -110,178 +95,103 @@ function isEnum(type) {
 }
 
 function getType(ctx, field) {
-    if (field.type === 'map') {
-        return ctx[getMapMessageName(field.tag)];
-    }
-    const path = field.type.split('.');
-    return path.reduce((ctx, name) => ctx && ctx[name], ctx);
+    if (field.type === 'map') return ctx[`${capitalize(field.name)}Entry`];
+    return field.type.split('.').reduce((ctx, name) => ctx && ctx[name], ctx);
 }
 
+function capitalize(s) {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function getSubMessage(ctx, field) {
+    const type = getType(ctx, field);
+    return type && type._proto.fields ? type : null;
+}
+
+// Map of scalar protobuf type → suffix used in read/write/readPacked method names,
+// plus per-type flags. `packable` matches the protobuf spec list of packable types.
+// `signed` is for varint types that take a signedness flag.
+const TYPES = {
+    string: {m: 'String'},
+    float: {m: 'Float', packable: true},
+    double: {m: 'Double', packable: true},
+    bool: {m: 'Boolean', packable: true},
+    uint32: {m: 'Varint', packable: true},
+    uint64: {m: 'Varint', packable: true},
+    int32: {m: 'Varint', packable: true, signed: true},
+    int64: {m: 'Varint', packable: true, signed: true},
+    sint32: {m: 'SVarint', packable: true},
+    sint64: {m: 'SVarint', packable: true},
+    fixed32: {m: 'Fixed32', packable: true},
+    fixed64: {m: 'Fixed64', packable: true},
+    sfixed32: {m: 'SFixed32', packable: true},
+    sfixed64: {m: 'SFixed64', packable: true},
+    bytes: {m: 'Bytes'},
+    enum: {m: 'Varint', packable: true},
+};
+
+function getMethod(ctx, field) {
+    if (isEnum(getType(ctx, field))) return TYPES.enum;
+    const t = TYPES[field.type];
+    if (!t) throw new Error(`Unexpected type: ${field.type}`);
+    return t;
+}
+
+// JS_STRING serializes numeric scalars as strings — applies to every TYPES entry except the non-numeric ones.
 function fieldShouldUseStringAsNumber(field) {
-    if (field.options.jstype === 'JS_STRING') {
-        switch (field.type) {
-        case 'float':
-        case 'double':
-        case 'uint32':
-        case 'uint64':
-        case 'int32':
-        case 'int64':
-        case 'sint32':
-        case 'sint64':
-        case 'fixed32':
-        case 'fixed64':
-        case 'sfixed32':
-        case 'sfixed64': return true;
-        default:         return false;
-        }
-    }
-    return false;
+    if (field.options.jstype !== 'JS_STRING') return false;
+    const t = TYPES[field.type];
+    return !!t && t.m !== 'String' && t.m !== 'Boolean' && t.m !== 'Bytes';
 }
 
 function compileScalarFieldRead(ctx, field) {
-    const type = getType(ctx, field);
-    if (type) {
-        if (type._proto.fields) return `read${type._name}(pbf, pbf.readVarint() + pbf.pos)`;
-        if (!isEnum(type)) throw new Error(`Unexpected type: ${type._name}`);
-    }
+    const sub = getSubMessage(ctx, field);
+    if (sub) return `read${sub._name}(pbf, pbf.readVarint() + pbf.pos)`;
 
-    const fieldType = isEnum(type) ? 'enum' : field.type;
-    const signed = fieldType === 'int32' || fieldType === 'int64' ? 'true' : '';
-    let suffix = `(${signed})`;
-
-    if (fieldShouldUseStringAsNumber(field)) {
-        suffix += '.toString()';
-    }
-
-    switch (fieldType) {
-    case 'string':   return `pbf.readString${suffix}`;
-    case 'float':    return `pbf.readFloat${suffix}`;
-    case 'double':   return `pbf.readDouble${suffix}`;
-    case 'bool':     return `pbf.readBoolean${suffix}`;
-    case 'enum':
-    case 'uint32':
-    case 'uint64':
-    case 'int32':
-    case 'int64':    return `pbf.readVarint${suffix}`;
-    case 'sint32':
-    case 'sint64':   return `pbf.readSVarint${suffix}`;
-    case 'fixed32':  return `pbf.readFixed32${suffix}`;
-    case 'fixed64':  return `pbf.readFixed64${suffix}`;
-    case 'sfixed32': return `pbf.readSFixed32${suffix}`;
-    case 'sfixed64': return `pbf.readSFixed64${suffix}`;
-    case 'bytes':    return `pbf.readBytes${suffix}`;
-    default:         throw new Error(`Unexpected type: ${field.type}`);
-    }
+    const {m, signed} = getMethod(ctx, field);
+    let suffix = `(${signed ? 'true' : ''})`;
+    if (fieldShouldUseStringAsNumber(field)) suffix += '.toString()';
+    return `pbf.read${m}${suffix}`;
 }
 
 function compilePackedRead(ctx, field) {
-    const type = getType(ctx, field);
-    const fieldType = isEnum(type) ? 'enum' : field.type;
-    const arr = `obj.${field.name}`;
+    const {m, signed} = getMethod(ctx, field);
+    return `pbf.readPacked${m}(obj.${field.name}${signed ? ', true' : ''})`;
+}
 
-    switch (fieldType) {
-    case 'float':    return `pbf.readPackedFloat(${arr})`;
-    case 'double':   return `pbf.readPackedDouble(${arr})`;
-    case 'bool':     return `pbf.readPackedBoolean(${arr})`;
-    case 'enum':
-    case 'uint32':
-    case 'uint64':   return `pbf.readPackedVarint(${arr})`;
-    case 'int32':
-    case 'int64':    return `pbf.readPackedVarint(${arr}, true)`;
-    case 'sint32':
-    case 'sint64':   return `pbf.readPackedSVarint(${arr})`;
-    case 'fixed32':  return `pbf.readPackedFixed32(${arr})`;
-    case 'fixed64':  return `pbf.readPackedFixed64(${arr})`;
-    case 'sfixed32': return `pbf.readPackedSFixed32(${arr})`;
-    case 'sfixed64': return `pbf.readPackedSFixed64(${arr})`;
-    default:         throw new Error(`Unexpected packed type: ${field.type}`);
+function compileFieldRead(ctx, field) {
+    const {type, name, repeated, oneof} = field;
+    let body;
+    if (repeated && willSupportPacked(ctx, field)) {
+        body = compilePackedRead(ctx, field);
+    } else {
+        const scalar = compileScalarFieldRead(ctx, field);
+        if (type === 'map') body = `const {key, value} = ${scalar}; obj.${name}[key] = value`;
+        else if (repeated) body = `obj.${name}.push(${scalar})`;
+        else body = `obj.${name} = ${scalar}`;
     }
+    if (oneof) body += `; obj.${oneof} = ${JSON.stringify(name)}`;
+    return type === 'map' || oneof ? `{ ${body}; }` : `${body};`;
 }
 
 function compileFieldWrite(ctx, field, name) {
-    let prefix = 'pbf.write';
-    if (isPacked(field)) prefix += 'Packed';
+    const sub = getSubMessage(ctx, field);
+    if (sub) return `pbf.writeMessage(${field.tag}, write${sub._name}, ${name})`;
 
     if (fieldShouldUseStringAsNumber(field)) {
-        if (field.type === 'float' || field.type === 'double') {
-            name = `parseFloat(${name})`;
-        } else {
-            name = `parseInt(${name}, 10)`;
-        }
+        name = field.type === 'float' || field.type === 'double' ?
+            `parseFloat(${name})` : `parseInt(${name}, 10)`;
     }
-    const postfix = `${isPacked(field) ? '' : 'Field'}(${field.tag}, ${name})`;
-
-    const type = getType(ctx, field);
-    if (type) {
-        if (type._proto.fields) return `${prefix}Message(${field.tag}, write${type._name}, ${name})`;
-        if (type._proto.values) return `${prefix}Varint${postfix}`;
-        throw new Error(`Unexpected type: ${type._name}`);
-    }
-
-    switch (field.type) {
-    case 'string':   return `${prefix}String${postfix}`;
-    case 'float':    return `${prefix}Float${postfix}`;
-    case 'double':   return `${prefix}Double${postfix}`;
-    case 'bool':     return `${prefix}Boolean${postfix}`;
-    case 'enum':
-    case 'uint32':
-    case 'uint64':
-    case 'int32':
-    case 'int64':    return `${prefix}Varint${postfix}`;
-    case 'sint32':
-    case 'sint64':   return `${prefix}SVarint${postfix}`;
-    case 'fixed32':  return `${prefix}Fixed32${postfix}`;
-    case 'fixed64':  return `${prefix}Fixed64${postfix}`;
-    case 'sfixed32': return `${prefix}SFixed32${postfix}`;
-    case 'sfixed64': return `${prefix}SFixed64${postfix}`;
-    case 'bytes':    return `${prefix}Bytes${postfix}`;
-    default:         throw new Error(`Unexpected type: ${field.type}`);
-    }
-}
-
-function compileMapRead(readCode, name) {
-    return `const {key, value} = ${readCode}; obj.${name}[key] = value`;
-}
-
-function compileRepeatedWrite(ctx, field) {
-    return `for (const item of obj.${field.name}) ${
-        compileFieldWrite(ctx, field, 'item')}`;
-}
-
-function compileMapWrite(ctx, field) {
-    const name = `obj.${field.name}`;
-
-    return `for (const key of Object.keys(${name})) ${
-        compileFieldWrite(ctx, field, `{key, value: ${name}[key]}`)}`;
-}
-
-function getMapMessageName(tag) {
-    return `_FieldEntry${tag}`;
-}
-
-function getMapField(name, type, tag) {
-    return {
-        name,
-        type,
-        tag,
-        map: null,
-        oneof: null,
-        required: false,
-        repeated: false,
-        options: {}
-    };
+    const {m} = getMethod(ctx, field);
+    const fn = isPacked(field) ? `writePacked${m}` : `write${m}Field`;
+    return `pbf.${fn}(${field.tag}, ${name})`;
 }
 
 function getMapMessage(field) {
+    const f = (name, type, tag) => ({name, type, tag, oneof: null, repeated: false, options: {}});
     return {
-        name: getMapMessageName(field.tag),
-        enums: [],
-        messages: [],
-        extensions: null,
-        fields: [
-            getMapField('key', field.map.from, 1),
-            getMapField('value', field.map.to, 2)
-        ]
+        name: `${capitalize(field.name)}Entry`,
+        fields: [f('key', field.map.from, 1), f('value', field.map.to, 2)],
     };
 }
 
@@ -304,154 +214,77 @@ function buildContext(proto, parent) {
     if (parent) {
         validateIdentifier(proto.name);
         parent[proto.name] = obj;
-
-        if (parent._name) {
-            obj._name = parent._name + proto.name;
-        } else {
-            obj._name = proto.name;
-        }
+        obj._name = (parent._name ?? '') + proto.name;
     }
 
-    if (proto.fields) {
-        for (const field of proto.fields) {
-            validateIdentifier(field.name);
-            if (field.oneof) validateIdentifier(field.oneof);
-        }
+    for (const field of proto.fields ?? []) {
+        validateIdentifier(field.name);
+        if (field.oneof) validateIdentifier(field.oneof);
     }
-    if (proto.values) {
-        for (const valueName of Object.keys(proto.values)) {
-            validateIdentifier(valueName);
-        }
-    }
+    for (const valueName of Object.keys(proto.values ?? {})) validateIdentifier(valueName);
 
-    for (let i = 0; proto.enums && i < proto.enums.length; i++) {
-        obj._children.push(buildContext(proto.enums[i], obj));
-    }
-
-    for (let i = 0; proto.messages && i < proto.messages.length; i++) {
-        obj._children.push(buildContext(proto.messages[i], obj));
-    }
-
-    for (let i = 0; proto.fields && i < proto.fields.length; i++) {
-        if (proto.fields[i].type === 'map') {
-            obj._children.push(buildContext(getMapMessage(proto.fields[i]), obj));
-        }
+    for (const e of proto.enums ?? []) obj._children.push(buildContext(e, obj));
+    for (const m of proto.messages ?? []) obj._children.push(buildContext(m, obj));
+    for (const f of proto.fields ?? []) {
+        if (f.type === 'map') obj._children.push(buildContext(getMapMessage(f), obj));
     }
 
     return obj;
 }
 
 function getDefaultValue(field, value) {
-    // Defaults not supported for repeated fields
-    if (field.repeated) return [];
-    let convertToStringIfNeeded = function (val) { return val; };
-    if (fieldShouldUseStringAsNumber(field)) {
-        convertToStringIfNeeded = function (val) { return val.toString(); };
-    }
+    if (field.repeated) return []; // defaults not supported for repeated fields
+    if (field.type === 'map') return {};
 
-    switch (field.type) {
-    case 'float':
-    case 'double':   return convertToStringIfNeeded(value ? parseFloat(value) : 0);
-    case 'uint32':
-    case 'uint64':
-    case 'int32':
-    case 'int64':
-    case 'sint32':
-    case 'sint64':
-    case 'fixed32':
-    case 'fixed64':
-    case 'sfixed32':
-    case 'sfixed64': return convertToStringIfNeeded(value ? parseInt(value, 10) : 0);
-    case 'string':   return value || '';
-    case 'bool':     return value === 'true';
-    case 'map':      return {};
-    default:         return undefined;
-    }
+    const t = TYPES[field.type];
+    if (!t || t.m === 'Bytes') return undefined; // unknown / message / bytes
+    if (t.m === 'String') return value || '';
+    if (t.m === 'Boolean') return value === 'true';
+
+    const isFloat = t.m === 'Float' || t.m === 'Double';
+    const num = value ? (isFloat ? parseFloat(value) : parseInt(value, 10)) : 0;
+    return fieldShouldUseStringAsNumber(field) ? num.toString() : num;
 }
 
 function willSupportPacked(ctx, field) {
-    const fieldType = isEnum(getType(ctx, field)) ? 'enum' : field.type;
-
-    switch (field.repeated && fieldType) {
-    case 'float':
-    case 'double':
-    case 'uint32':
-    case 'uint64':
-    case 'int32':
-    case 'int64':
-    case 'sint32':
-    case 'sint64':
-    case 'fixed32':
-    case 'fixed64':
-    case 'sfixed32':
-    case 'enum':
-    case 'bool': return true;
-    }
-
-    return false;
+    if (!field.repeated || getSubMessage(ctx, field)) return false;
+    return !!getMethod(ctx, field).packable;
 }
 
 function setPackedOption(ctx, field, syntax) {
-    // No default packed in older protobuf versions
-    if (syntax < 3) return;
-
-    // Packed option already set
-    if (field.options.packed !== undefined) return;
-
-    // Not a packed field type
-    if (!willSupportPacked(ctx, field)) return;
-
-    field.options.packed = 'true';
+    // proto3 packs eligible repeated fields by default; older syntax requires explicit [packed=true].
+    if (syntax >= 3 && field.options.packed === undefined && willSupportPacked(ctx, field)) {
+        field.options.packed = 'true';
+    }
 }
 
 function setDefaultValue(ctx, field, syntax) {
-    const options = field.options;
     const type = getType(ctx, field);
-    const enumValues = type && type._proto.values && getEnumValues(type);
-
     // Proto3 does not support overriding defaults
-    const explicitDefault = syntax < 3 ? options.default : undefined;
+    const explicitDefault = syntax < 3 ? field.options.default : undefined;
 
-    // Set default for enum values
-    if (enumValues && !field.repeated) {
-        ctx._defaults[field.name] = enumValues[explicitDefault] || 0;
-
-    } else {
-        ctx._defaults[field.name] = getDefaultValue(field, explicitDefault);
-    }
+    ctx._defaults[field.name] = isEnum(type) && !field.repeated ?
+        (getEnumValues(type)[explicitDefault] || 0) :
+        getDefaultValue(field, explicitDefault);
 }
 
 function buildDefaults(ctx, syntax) {
-    const proto = ctx._proto;
-
-    for (let i = 0; i < ctx._children.length; i++) {
-        buildDefaults(ctx._children[i], syntax);
+    for (const child of ctx._children) buildDefaults(child, syntax);
+    for (const field of ctx._proto.fields ?? []) {
+        setPackedOption(ctx, field, syntax);
+        setDefaultValue(ctx, field, syntax);
     }
-
-    if (proto.fields) {
-        for (let i = 0; i < proto.fields.length; i++) {
-            setPackedOption(ctx, proto.fields[i], syntax);
-            setDefaultValue(ctx, proto.fields[i], syntax);
-        }
-    }
-
     return ctx;
 }
 
 function getDefaultWriteTest(ctx, field) {
     const def = ctx._defaults[field.name];
-    const type = getType(ctx, field);
     let code = `    if (obj.${field.name}`;
 
-    if (!field.repeated && (!type || !type._proto.fields)) {
-        if (def === undefined || def || field.oneof) {
-            code += ' != null';
-        }
-        if (def) {
-            code += ` && obj.${field.name} !== ${JSON.stringify(def)}`;
-        }
+    if (!field.repeated && !getSubMessage(ctx, field)) {
+        if (def === undefined || def || field.oneof) code += ' != null';
+        if (def) code += ` && obj.${field.name} !== ${JSON.stringify(def)}`;
     }
-
     return `${code}) `;
 }
 

--- a/compile.js
+++ b/compile.js
@@ -31,33 +31,35 @@ function writeMessage(ctx, options) {
 
     if (!options.noRead) {
         const readName = `read${ctx._name}`;
-        code +=
-`${writeFunctionExport(options, readName)}function ${readName}(pbf, end) {
-    return pbf.readFields(${readName}Field, ${compileDest(ctx)}, end);
-}
-function ${readName}Field(tag, obj, pbf) {
-`;
+        const hasPackable = fields.some(f => f.repeated && willSupportPacked(ctx, f));
+
+        code += `${writeFunctionExport(options, readName)}function ${readName}(pbf, end = pbf.length) {\n`;
+        code += `    const obj = ${compileDest(ctx)};\n`;
+        code += '    while (pbf.pos < end) {\n';
+        code += `        const tag = pbf.readVarint(), field = tag >>> 3${hasPackable ? '; pbf.type = tag & 7' : ''};\n`;
+
         for (let i = 0; i < fields.length; i++) {
             const field = fields[i];
-            const {type, name, repeated, oneof, tag} = field;
-            const readCode = compileFieldRead(ctx, field);
-            const packed = willSupportPacked(ctx, field);
+            const {type, name, repeated, oneof} = field;
+            const packable = willSupportPacked(ctx, field);
 
-            let fieldRead =
-                type === 'map' ? compileMapRead(readCode, name) :
-                repeated ? (packed ? readCode : `obj.${name}.push(${readCode})`) :
-                `obj.${name} = ${readCode}`;
+            const wrap = body => (type === 'map' || oneof ? `{ ${body}; }` : `${body};`);
+            const oneofTail = oneof ? `; obj.${oneof} = ${JSON.stringify(name)}` : '';
 
-            if (oneof) {
-                fieldRead += `; obj.${oneof} = ${JSON.stringify(name)}`;
-            }
+            const scalarRead = compileScalarFieldRead(ctx, field);
+            const body =
+                repeated && packable ? compilePackedRead(ctx, field) :
+                type === 'map' ? compileMapRead(scalarRead, name) :
+                repeated ? `obj.${name}.push(${scalarRead})` :
+                `obj.${name} = ${scalarRead}`;
 
-            fieldRead = type === 'map' || oneof ? `{ ${fieldRead}; }` : `${fieldRead};`;
-
-            code +=
-`    ${i ? 'else ' : ''}if (tag === ${tag}) ${fieldRead}\n`;
+            code += `        ${i ? 'else ' : ''}if (field === ${field.tag}) ${wrap(body + oneofTail)}\n`;
         }
-        code += '}\n';
+        code += `        ${fields.length ? 'else ' : ''}pbf.skip(tag);\n`;
+        code += `    }
+    return obj;
+}
+`;
     }
 
     if (!options.noWrite) {
@@ -136,7 +138,7 @@ function fieldShouldUseStringAsNumber(field) {
     return false;
 }
 
-function compileFieldRead(ctx, field) {
+function compileScalarFieldRead(ctx, field) {
     const type = getType(ctx, field);
     if (type) {
         if (type._proto.fields) return `read${type._name}(pbf, pbf.readVarint() + pbf.pos)`;
@@ -144,38 +146,55 @@ function compileFieldRead(ctx, field) {
     }
 
     const fieldType = isEnum(type) ? 'enum' : field.type;
-
-    let prefix = 'pbf.read';
     const signed = fieldType === 'int32' || fieldType === 'int64' ? 'true' : '';
     let suffix = `(${signed})`;
-
-    if (willSupportPacked(ctx, field)) {
-        prefix += 'Packed';
-        suffix = `(obj.${field.name}${signed ? `, ${signed}` : ''})`;
-    }
 
     if (fieldShouldUseStringAsNumber(field)) {
         suffix += '.toString()';
     }
 
     switch (fieldType) {
-    case 'string':   return `${prefix}String${suffix}`;
-    case 'float':    return `${prefix}Float${suffix}`;
-    case 'double':   return `${prefix}Double${suffix}`;
-    case 'bool':     return `${prefix}Boolean${suffix}`;
+    case 'string':   return `pbf.readString${suffix}`;
+    case 'float':    return `pbf.readFloat${suffix}`;
+    case 'double':   return `pbf.readDouble${suffix}`;
+    case 'bool':     return `pbf.readBoolean${suffix}`;
     case 'enum':
     case 'uint32':
     case 'uint64':
     case 'int32':
-    case 'int64':    return `${prefix}Varint${suffix}`;
+    case 'int64':    return `pbf.readVarint${suffix}`;
     case 'sint32':
-    case 'sint64':   return `${prefix}SVarint${suffix}`;
-    case 'fixed32':  return `${prefix}Fixed32${suffix}`;
-    case 'fixed64':  return `${prefix}Fixed64${suffix}`;
-    case 'sfixed32': return `${prefix}SFixed32${suffix}`;
-    case 'sfixed64': return `${prefix}SFixed64${suffix}`;
-    case 'bytes':    return `${prefix}Bytes${suffix}`;
+    case 'sint64':   return `pbf.readSVarint${suffix}`;
+    case 'fixed32':  return `pbf.readFixed32${suffix}`;
+    case 'fixed64':  return `pbf.readFixed64${suffix}`;
+    case 'sfixed32': return `pbf.readSFixed32${suffix}`;
+    case 'sfixed64': return `pbf.readSFixed64${suffix}`;
+    case 'bytes':    return `pbf.readBytes${suffix}`;
     default:         throw new Error(`Unexpected type: ${field.type}`);
+    }
+}
+
+function compilePackedRead(ctx, field) {
+    const type = getType(ctx, field);
+    const fieldType = isEnum(type) ? 'enum' : field.type;
+    const arr = `obj.${field.name}`;
+
+    switch (fieldType) {
+    case 'float':    return `pbf.readPackedFloat(${arr})`;
+    case 'double':   return `pbf.readPackedDouble(${arr})`;
+    case 'bool':     return `pbf.readPackedBoolean(${arr})`;
+    case 'enum':
+    case 'uint32':
+    case 'uint64':   return `pbf.readPackedVarint(${arr})`;
+    case 'int32':
+    case 'int64':    return `pbf.readPackedVarint(${arr}, true)`;
+    case 'sint32':
+    case 'sint64':   return `pbf.readPackedSVarint(${arr})`;
+    case 'fixed32':  return `pbf.readPackedFixed32(${arr})`;
+    case 'fixed64':  return `pbf.readPackedFixed64(${arr})`;
+    case 'sfixed32': return `pbf.readPackedSFixed32(${arr})`;
+    case 'sfixed64': return `pbf.readPackedSFixed64(${arr})`;
+    default:         throw new Error(`Unexpected packed type: ${field.type}`);
     }
 }
 

--- a/compile.js
+++ b/compile.js
@@ -95,7 +95,7 @@ function isEnum(type) {
 }
 
 function getType(ctx, field) {
-    if (field.type === 'map') return ctx[`${capitalize(field.name)}Entry`];
+    if (field.type === 'map') return ctx._mapEntries[field.name];
     return field.type.split('.').reduce((ctx, name) => ctx && ctx[name], ctx);
 }
 
@@ -205,16 +205,21 @@ function validateIdentifier(name) {
     }
 }
 
-function buildContext(proto, parent) {
+function buildContext(proto, parent, mapEntryField) {
     const obj = Object.create(parent);
     obj._proto = proto;
     obj._children = [];
     obj._defaults = {};
+    obj._mapEntries = {};
 
     if (parent) {
-        validateIdentifier(proto.name);
-        parent[proto.name] = obj;
         obj._name = (parent._name ?? '') + proto.name;
+        if (mapEntryField) {
+            parent._mapEntries[mapEntryField.name] = obj;
+        } else {
+            validateIdentifier(proto.name);
+            parent[proto.name] = obj;
+        }
     }
 
     for (const field of proto.fields ?? []) {
@@ -226,7 +231,12 @@ function buildContext(proto, parent) {
     for (const e of proto.enums ?? []) obj._children.push(buildContext(e, obj));
     for (const m of proto.messages ?? []) obj._children.push(buildContext(m, obj));
     for (const f of proto.fields ?? []) {
-        if (f.type === 'map') obj._children.push(buildContext(getMapMessage(f), obj));
+        if (f.type !== 'map') continue;
+        const entryProto = getMapMessage(f);
+        // Disambiguate against sibling messages/enums with a `$` suffix — `$` is a valid
+        // JS identifier char but disallowed in protobuf identifiers, so it can't re-collide.
+        if (obj._children.some(c => c._proto.name === entryProto.name)) entryProto.name += '$';
+        obj._children.push(buildContext(entryProto, obj, f));
     }
 
     return obj;

--- a/index.js
+++ b/index.js
@@ -636,7 +636,7 @@ function makeRoomForExtraLength(startPos, len, pbf) {
 
     // if 1 byte isn't enough for encoding message length, shift the data to the right
     pbf.realloc(extraLen);
-    for (let i = pbf.pos - 1; i >= startPos; i--) pbf.buf[i + extraLen] = pbf.buf[i];
+    pbf.buf.copyWithin(startPos + extraLen, startPos, pbf.pos);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -96,9 +96,10 @@ export class PbfReader {
      */
     readVarint(isSigned) {
         const buf = this.buf;
-        let val, b;
+        const b0 = buf[this.pos++];
+        if (b0 < 0x80) return b0;
 
-        b = buf[this.pos++]; val  =  b & 0x7f;        if (b < 0x80) return val;
+        let val = b0 & 0x7f, b;
         b = buf[this.pos++]; val |= (b & 0x7f) << 7;  if (b < 0x80) return val;
         b = buf[this.pos++]; val |= (b & 0x7f) << 14; if (b < 0x80) return val;
         b = buf[this.pos++]; val |= (b & 0x7f) << 21; if (b < 0x80) return val;
@@ -283,6 +284,12 @@ export class PbfWriter {
     /** @param {number} val */
     writeVarint(val) {
         val = +val || 0;
+
+        if (val >= 0 && val < 0x80) {
+            if (this.pos >= this.length) this.realloc(1);
+            this.buf[this.pos++] = val;
+            return;
+        }
 
         if (val > 0xfffffff || val < 0) {
             writeBigVarint(val, this);

--- a/index.js
+++ b/index.js
@@ -346,7 +346,8 @@ export class PbfWriter {
         const len = buffer.length;
         this.writeVarint(len);
         this.realloc(len);
-        for (let i = 0; i < len; i++) this.buf[this.pos++] = buffer[i];
+        this.buf.set(buffer, this.pos);
+        this.pos += len;
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -107,10 +107,6 @@ export class PbfReader {
         return readVarintRemainder(val, isSigned, this);
     }
 
-    readVarint64() { // for compatibility with v2.0.1
-        return this.readVarint(true);
-    }
-
     readSVarint() {
         const num = this.readVarint();
         return num % 2 === 1 ? (num + 1) / -2 : num / 2; // zigzag encoding

--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ const PBF_FIXED64 = 1; // 64-bit: double, fixed64, sfixed64
 const PBF_BYTES   = 2; // length-delimited: string, bytes, embedded messages, packed repeated fields
 const PBF_FIXED32 = 5; // 32-bit: float, fixed32, sfixed32
 
-export default class Pbf {
+export class PbfReader {
     /**
-     * @param {Uint8Array | ArrayBuffer} [buf]
+     * @param {Uint8Array | ArrayBuffer} buf
      */
-    constructor(buf = new Uint8Array(16)) {
+    constructor(buf) {
         this.buf = ArrayBuffer.isView(buf) ? buf : new Uint8Array(buf);
         this.dataView = new DataView(this.buf.buffer);
         this.pos = 0;
@@ -24,11 +24,9 @@ export default class Pbf {
         this.length = this.buf.length;
     }
 
-    // === READING =================================================================
-
     /**
      * @template T
-     * @param {(tag: number, result: T, pbf: Pbf) => void} readField
+     * @param {(tag: number, result: T, pbf: PbfReader) => void} readField
      * @param {T} result
      * @param {number} [end]
      */
@@ -48,7 +46,7 @@ export default class Pbf {
 
     /**
      * @template T
-     * @param {(tag: number, result: T, pbf: Pbf) => void} readField
+     * @param {(tag: number, result: T, pbf: PbfReader) => void} readField
      * @param {T} result
      */
     readMessage(readField, result) {
@@ -214,8 +212,18 @@ export default class Pbf {
         else if (type === PBF_FIXED64) this.pos += 8;
         else throw new Error(`Unimplemented type: ${type}`);
     }
+}
 
-    // === WRITING =================================================================
+export class PbfWriter {
+    /**
+     * @param {Uint8Array | ArrayBuffer} [buf]
+     */
+    constructor(buf = new Uint8Array(16)) {
+        this.buf = ArrayBuffer.isView(buf) ? buf : new Uint8Array(buf);
+        this.dataView = new DataView(this.buf.buffer);
+        this.pos = 0;
+        this.length = this.buf.length;
+    }
 
     /**
      * @param {number} tag
@@ -347,7 +355,7 @@ export default class Pbf {
 
     /**
      * @template T
-     * @param {(obj: T, pbf: Pbf) => void} fn
+     * @param {(obj: T, pbf: PbfWriter) => void} fn
      * @param {T} obj
      */
     writeRawMessage(fn, obj) {
@@ -369,7 +377,7 @@ export default class Pbf {
     /**
      * @template T
      * @param {number} tag
-     * @param {(obj: T, pbf: Pbf) => void} fn
+     * @param {(obj: T, pbf: PbfWriter) => void} fn
      * @param {T} obj
      */
     writeMessage(tag, fn, obj) {
@@ -528,12 +536,12 @@ export default class Pbf {
     writeBooleanField(tag, val) {
         this.writeVarintField(tag, +val);
     }
-};
+}
 
 /**
  * @param {number} l
  * @param {boolean | undefined} s
- * @param {Pbf} p
+ * @param {PbfReader} p
  */
 function readVarintRemainder(l, s, p) {
     const buf = p.buf;
@@ -560,7 +568,7 @@ function toNum(low, high, isSigned) {
 
 /**
  * @param {number} val
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writeBigVarint(val, pbf) {
     let low, high;
@@ -593,7 +601,7 @@ function writeBigVarint(val, pbf) {
 /**
  * @param {number} high
  * @param {number} low
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writeBigVarintLow(low, high, pbf) {
     pbf.buf[pbf.pos++] = low & 0x7f | 0x80; low >>>= 7;
@@ -605,7 +613,7 @@ function writeBigVarintLow(low, high, pbf) {
 
 /**
  * @param {number} high
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writeBigVarintHigh(high, pbf) {
     const lsb = (high & 0x07) << 4;
@@ -621,7 +629,7 @@ function writeBigVarintHigh(high, pbf) {
 /**
  * @param {number} startPos
  * @param {number} len
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function makeRoomForExtraLength(startPos, len, pbf) {
     const extraLen =
@@ -636,63 +644,63 @@ function makeRoomForExtraLength(startPos, len, pbf) {
 
 /**
  * @param {number[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedVarint(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeVarint(arr[i]);
 }
 /**
  * @param {number[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedSVarint(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeSVarint(arr[i]);
 }
 /**
  * @param {number[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedFloat(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeFloat(arr[i]);
 }
 /**
  * @param {number[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedDouble(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeDouble(arr[i]);
 }
 /**
  * @param {boolean[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedBoolean(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeBoolean(arr[i]);
 }
 /**
  * @param {number[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedFixed32(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeFixed32(arr[i]);
 }
 /**
  * @param {number[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedSFixed32(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeSFixed32(arr[i]);
 }
 /**
  * @param {number[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedFixed64(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeFixed64(arr[i]);
 }
 /**
  * @param {number[]} arr
- * @param {Pbf} pbf
+ * @param {PbfWriter} pbf
  */
 function writePackedSFixed64(arr, pbf) {
     for (let i = 0; i < arr.length; i++) pbf.writeSFixed64(arr[i]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pbf",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pbf",
-      "version": "4.0.2",
+      "version": "5.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "scripts": {
     "bench": "node bench/bench.js",
-    "pretest": "eslint *.js compile.js test/*.js test/fixtures/*.js bin/pbf",
-    "test": "tsc && node --test",
-    "cov": "node --test --experimental-test-covetage",
+    "pretest": "eslint *.js compile.js test/*.js test/fixtures/*.js bench/*.js bin/pbf && tsc",
+    "test": "node --test test/*.test.js",
+    "cov": "node --test --experimental-test-coverage test/*.test.js",
     "build": "rollup -c",
     "prepublishOnly": "npm run test && npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbf",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "a low-level, lightweight protocol buffers implementation in JavaScript",
   "main": "index.js",
   "type": "module",

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -3,7 +3,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {sync as resolve} from 'resolve-protobuf-schema';
 
-import Pbf from '../index.js';
+import {PbfReader, PbfWriter} from '../index.js';
 import {compile, compileRaw} from '../compile.js';
 
 test('compiles all proto files to proper js', () => {
@@ -27,10 +27,10 @@ test('compiles vector tile proto', () => {
     const tileBuf = fs.readFileSync(new URL('fixtures/12665.vector.pbf', import.meta.url));
     const {readTile, writeTile} = compile(proto);
 
-    const tile = readTile(new Pbf(tileBuf));
+    const tile = readTile(new PbfReader(tileBuf));
     assert.equal(tile.layers.length, 11);
 
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
     writeTile(tile, pbf);
     const buf = pbf.finish();
     assert.equal(buf.length, 124946);
@@ -49,11 +49,11 @@ test('compiles packed proto', () => {
         types: [0, 1, 0, 1],
         value: [300, 400, 500]
     };
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
     writeNotPacked(original, pbf);
     const buf = pbf.finish();
 
-    const decompressed = readFalsePacked(new Pbf(buf));
+    const decompressed = readFalsePacked(new PbfReader(buf));
     assert.equal(buf.length, 17);
     assert.deepEqual(original, decompressed);
 });
@@ -66,11 +66,11 @@ test('reads packed with unpacked field', () => {
         types: [0, 1, 0, 1],
         value: [300, 400, 500]
     };
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
     writePacked(original, pbf);
     const buf = pbf.finish();
 
-    const decompressed = readFalsePacked(new Pbf(buf));
+    const decompressed = readFalsePacked(new PbfReader(buf));
     assert.equal(buf.length, 14);
     assert.deepEqual(original, decompressed);
 });
@@ -83,15 +83,15 @@ test('compiles packed proto3', () => {
         types: [0, 1, 0, 1],
         value: [300, 400, 500]
     };
-    let pbf = new Pbf();
+    let pbf = new PbfWriter();
     writeFalsePacked(original, pbf);
     const falsePackedBuf = pbf.finish();
 
-    pbf = new Pbf();
+    pbf = new PbfWriter();
     writeNotPacked(original, pbf);
     const notPackedBuf = pbf.finish();
 
-    const decompressed = readNotPacked(new Pbf(falsePackedBuf));
+    const decompressed = readNotPacked(new PbfReader(falsePackedBuf));
     assert.deepEqual(original, decompressed);
     assert.equal(notPackedBuf.length, 14);
     assert.ok(falsePackedBuf.length > notPackedBuf.length, 'Did not respect [packed=false]');
@@ -104,11 +104,11 @@ test('compiles packed with multi-byte tags', () => {
     const original = {
         value: [300, 400, 500]
     };
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
     writePacked(original, pbf);
     const buf = pbf.finish();
 
-    const decompressed = readPacked(new Pbf(buf));
+    const decompressed = readPacked(new PbfReader(buf));
     assert.equal(buf.length, 9);
     assert.deepEqual(original, decompressed);
 });
@@ -116,12 +116,12 @@ test('compiles packed with multi-byte tags', () => {
 test('compiles defaults', () => {
     const proto = resolve(new URL('fixtures/defaults.proto', import.meta.url));
     const {readEnvelope, writeEnvelope} = compile(proto);
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
 
     writeEnvelope({}, pbf);
 
     const buf = pbf.finish();
-    const data = readEnvelope(new Pbf(buf));
+    const data = readEnvelope(new PbfReader(buf));
 
     assert.equal(buf.length, 0);
     assert.deepEqual(data, {
@@ -136,12 +136,12 @@ test('compiles defaults', () => {
 test('compiles proto3 ignoring defaults', () => {
     const proto = resolve(new URL('fixtures/defaults_proto3.proto', import.meta.url));
     const {readEnvelope, writeEnvelope} = compile(proto);
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
 
     writeEnvelope({}, pbf);
 
     const buf = pbf.finish();
-    const data = readEnvelope(new Pbf(buf));
+    const data = readEnvelope(new PbfReader(buf));
 
     assert.equal(buf.length, 0);
 
@@ -167,11 +167,11 @@ test('compiles maps', () => {
         }
     };
 
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
     writeEnvelope(original, pbf);
     const buf = pbf.finish();
 
-    const decompressed = readEnvelope(new Pbf(buf));
+    const decompressed = readEnvelope(new PbfReader(buf));
 
     assert.deepEqual(original, decompressed);
 });
@@ -179,7 +179,7 @@ test('compiles maps', () => {
 test('does not write undefined or null values', () => {
     const proto = resolve(new URL('fixtures/embedded_type.proto', import.meta.url));
     const {writeEmbeddedType} = compile(proto);
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
 
     writeEmbeddedType({}, pbf);
 
@@ -195,11 +195,11 @@ test('does not write undefined or null values', () => {
 test('handles all implicit default values', () => {
     const proto = resolve(new URL('fixtures/defaults_implicit.proto', import.meta.url));
     const {readEnvelope, writeEnvelope} = compile(proto);
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
 
     writeEnvelope({}, pbf);
     const buf = pbf.finish();
-    const data = readEnvelope(new Pbf(buf));
+    const data = readEnvelope(new PbfReader(buf));
 
     assert.equal(buf.length, 0);
 
@@ -218,28 +218,28 @@ test('handles all implicit default values', () => {
 test('sets oneof field name', () => {
     const proto = resolve(new URL('fixtures/oneof.proto', import.meta.url));
     const {readEnvelope, writeEnvelope} = compile(proto);
-    let pbf = new Pbf();
+    let pbf = new PbfWriter();
 
     writeEnvelope({}, pbf);
-    let data = readEnvelope(new Pbf(pbf.finish()));
+    let data = readEnvelope(new PbfReader(pbf.finish()));
 
     assert.equal(data.value, undefined);
     assert.equal(data.id, 0);
 
-    pbf = new Pbf();
+    pbf = new PbfWriter();
     writeEnvelope({
         float: 1.5
     }, pbf);
-    data = readEnvelope(new Pbf(pbf.finish()));
+    data = readEnvelope(new PbfReader(pbf.finish()));
 
     assert.equal(data.value, 'float');
     assert.equal(data[data.value], 1.5);
 
-    pbf = new Pbf();
+    pbf = new PbfWriter();
     writeEnvelope({
         float: 0
     }, pbf);
-    data = readEnvelope(new Pbf(pbf.finish()));
+    data = readEnvelope(new PbfReader(pbf.finish()));
 
     assert.equal(data.value, 'float');
     assert.equal(data[data.value], 0);
@@ -248,7 +248,7 @@ test('sets oneof field name', () => {
 test('handles jstype=JS_STRING', () => {
     const proto = resolve(new URL('fixtures/type_string.proto', import.meta.url));
     const {readTypeString, writeTypeString, readTypeNotString} = compile(proto);
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
 
     writeTypeString({
         int: '-5',
@@ -258,7 +258,7 @@ test('handles jstype=JS_STRING', () => {
     }, pbf);
 
     const buf = pbf.finish();
-    let data = readTypeString(new Pbf(buf));
+    let data = readTypeString(new PbfReader(buf));
 
     assert.equal(data.int, '-5');
     assert.equal(data.long, '10000');
@@ -267,7 +267,7 @@ test('handles jstype=JS_STRING', () => {
     assert.equal(data.default_implicit, '0');
     assert.equal(data.default_explicit, '42');
 
-    data = readTypeNotString(new Pbf(buf));
+    data = readTypeNotString(new PbfReader(buf));
     assert.equal(data.int, -5);
     assert.equal(data.long, 10000);
     assert.equal(data.boolVal, true);
@@ -277,7 +277,7 @@ test('handles jstype=JS_STRING', () => {
 test('handles negative varint', () => {
     const proto = resolve(new URL('fixtures/varint.proto', import.meta.url));
     const {readEnvelope, writeEnvelope} = compile(proto);
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
 
     writeEnvelope({
         int: -5,
@@ -285,7 +285,7 @@ test('handles negative varint', () => {
     }, pbf);
 
     const buf = pbf.finish();
-    const data = readEnvelope(new Pbf(buf));
+    const data = readEnvelope(new PbfReader(buf));
 
     assert.equal(data.int, -5);
     assert.equal(data.long, -10);
@@ -294,7 +294,7 @@ test('handles negative varint', () => {
 test('handles unsigned varint', () => {
     const proto = resolve(new URL('fixtures/varint.proto', import.meta.url));
     const {readEnvelope, writeEnvelope} = compile(proto);
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
 
     writeEnvelope({
         uint: Math.pow(2, 31),
@@ -302,7 +302,7 @@ test('handles unsigned varint', () => {
     }, pbf);
 
     const buf = pbf.finish();
-    const data = readEnvelope(new Pbf(buf));
+    const data = readEnvelope(new PbfReader(buf));
 
     assert.equal(data.uint, Math.pow(2, 31));
     assert.equal(data.ulong, Math.pow(2, 63));

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -14,10 +14,10 @@ test('compiles all proto files to proper js', () => {
         const proto = resolve(new URL(`fixtures/${path}`, import.meta.url));
         const js = compileRaw(proto, {dev: true});
 
-        // uncomment to update the fixtures
-        // fs.writeFileSync(new URL(`fixtures/${path}`.replace('.proto', '.js'), import.meta.url), js);
+        const jsPath = new URL(`fixtures/${path}`.replace('.proto', '.js'), import.meta.url);
+        if (process.env.UPDATE) fs.writeFileSync(jsPath, js);
 
-        const expectedJS = fs.readFileSync(new URL(`fixtures/${path}`.replace('.proto', '.js'), import.meta.url), 'utf8');
+        const expectedJS = fs.readFileSync(jsPath, 'utf8');
         assert.equal(js, expectedJS);
     }
 });
@@ -111,6 +111,20 @@ test('compiles packed with multi-byte tags', () => {
     const decompressed = readPacked(new PbfReader(buf));
     assert.equal(buf.length, 9);
     assert.deepEqual(original, decompressed);
+});
+
+test('compiles packed sfixed64', () => {
+    const proto = resolve(new URL('fixtures/packed_proto3.proto', import.meta.url));
+    const {readPackedFixed, writePackedFixed} = compile(proto);
+
+    const original = {value: [1, -2, 3000000000, -3000000000]};
+    const pbf = new PbfWriter();
+    writePackedFixed(original, pbf);
+    const buf = pbf.finish();
+
+    // length-delimited (wire-type 2) packed form: 1 byte tag + 1 byte length + 4*8 bytes payload
+    assert.equal(buf.length, 34);
+    assert.deepEqual(readPackedFixed(new PbfReader(buf)), original);
 });
 
 test('compiles defaults', () => {

--- a/test/fixtures/defaults.js
+++ b/test/fixtures/defaults.js
@@ -4,15 +4,18 @@ export const MessageType = {
     "GREETING": 1
 };
 
-export function readEnvelope(pbf, end) {
-    return pbf.readFields(readEnvelopeField, {type: 1, name: "test", flag: true, weight: 1.5, id: 1}, end);
-}
-function readEnvelopeField(tag, obj, pbf) {
-    if (tag === 1) obj.type = pbf.readVarint();
-    else if (tag === 2) obj.name = pbf.readString();
-    else if (tag === 3) obj.flag = pbf.readBoolean();
-    else if (tag === 4) obj.weight = pbf.readFloat();
-    else if (tag === 5) obj.id = pbf.readVarint(true);
+export function readEnvelope(pbf, end = pbf.length) {
+    const obj = {type: 1, name: "test", flag: true, weight: 1.5, id: 1};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.type = pbf.readVarint();
+        else if (field === 2) obj.name = pbf.readString();
+        else if (field === 3) obj.flag = pbf.readBoolean();
+        else if (field === 4) obj.weight = pbf.readFloat();
+        else if (field === 5) obj.id = pbf.readVarint(true);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEnvelope(obj, pbf) {
     if (obj.type != null && obj.type !== 1) pbf.writeVarintField(1, obj.type);

--- a/test/fixtures/defaults_implicit.js
+++ b/test/fixtures/defaults_implicit.js
@@ -4,28 +4,34 @@ export const MessageType = {
     "GREETING": 1
 };
 
-export function readCustomType(pbf, end) {
-    return pbf.readFields(readCustomTypeField, {}, end);
-}
-function readCustomTypeField(tag, obj, pbf) {
+export function readCustomType(pbf, end = pbf.length) {
+    const obj = {};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeCustomType(obj, pbf) {
 }
 
-export function readEnvelope(pbf, end) {
-    return pbf.readFields(readEnvelopeField, {type: 0, name: "", flag: false, weight: 0, id: 0, tags: [], numbers: [], bytes: undefined, custom: undefined, types: []}, end);
-}
-function readEnvelopeField(tag, obj, pbf) {
-    if (tag === 1) obj.type = pbf.readVarint();
-    else if (tag === 2) obj.name = pbf.readString();
-    else if (tag === 3) obj.flag = pbf.readBoolean();
-    else if (tag === 4) obj.weight = pbf.readFloat();
-    else if (tag === 5) obj.id = pbf.readVarint(true);
-    else if (tag === 6) obj.tags.push(pbf.readString());
-    else if (tag === 7) pbf.readPackedVarint(obj.numbers, true);
-    else if (tag === 8) obj.bytes = pbf.readBytes();
-    else if (tag === 9) obj.custom = readCustomType(pbf, pbf.readVarint() + pbf.pos);
-    else if (tag === 10) pbf.readPackedVarint(obj.types);
+export function readEnvelope(pbf, end = pbf.length) {
+    const obj = {type: 0, name: "", flag: false, weight: 0, id: 0, tags: [], numbers: [], bytes: undefined, custom: undefined, types: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 1) obj.type = pbf.readVarint();
+        else if (field === 2) obj.name = pbf.readString();
+        else if (field === 3) obj.flag = pbf.readBoolean();
+        else if (field === 4) obj.weight = pbf.readFloat();
+        else if (field === 5) obj.id = pbf.readVarint(true);
+        else if (field === 6) obj.tags.push(pbf.readString());
+        else if (field === 7) pbf.readPackedVarint(obj.numbers, true);
+        else if (field === 8) obj.bytes = pbf.readBytes();
+        else if (field === 9) obj.custom = readCustomType(pbf, pbf.readVarint() + pbf.pos);
+        else if (field === 10) pbf.readPackedVarint(obj.types);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEnvelope(obj, pbf) {
     if (obj.type) pbf.writeVarintField(1, obj.type);

--- a/test/fixtures/defaults_proto3.js
+++ b/test/fixtures/defaults_proto3.js
@@ -4,15 +4,18 @@ export const MessageType = {
     "GREETING": 1
 };
 
-export function readEnvelope(pbf, end) {
-    return pbf.readFields(readEnvelopeField, {type: 0, name: "", flag: false, weight: 0, id: 0}, end);
-}
-function readEnvelopeField(tag, obj, pbf) {
-    if (tag === 1) obj.type = pbf.readVarint();
-    else if (tag === 2) obj.name = pbf.readString();
-    else if (tag === 3) obj.flag = pbf.readBoolean();
-    else if (tag === 4) obj.weight = pbf.readFloat();
-    else if (tag === 5) obj.id = pbf.readVarint(true);
+export function readEnvelope(pbf, end = pbf.length) {
+    const obj = {type: 0, name: "", flag: false, weight: 0, id: 0};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.type = pbf.readVarint();
+        else if (field === 2) obj.name = pbf.readString();
+        else if (field === 3) obj.flag = pbf.readBoolean();
+        else if (field === 4) obj.weight = pbf.readFloat();
+        else if (field === 5) obj.id = pbf.readVarint(true);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEnvelope(obj, pbf) {
     if (obj.type) pbf.writeVarintField(1, obj.type);

--- a/test/fixtures/embedded_type.js
+++ b/test/fixtures/embedded_type.js
@@ -1,11 +1,14 @@
 
-export function readEmbeddedType(pbf, end) {
-    return pbf.readFields(readEmbeddedTypeField, {value: "test", sub_field: undefined, sub_sub_field: undefined}, end);
-}
-function readEmbeddedTypeField(tag, obj, pbf) {
-    if (tag === 1) obj.value = pbf.readString();
-    else if (tag === 4) obj.sub_field = readEmbeddedTypeContainer(pbf, pbf.readVarint() + pbf.pos);
-    else if (tag === 5) obj.sub_sub_field = readEmbeddedTypeContainerInner(pbf, pbf.readVarint() + pbf.pos);
+export function readEmbeddedType(pbf, end = pbf.length) {
+    const obj = {value: "test", sub_field: undefined, sub_sub_field: undefined};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.value = pbf.readString();
+        else if (field === 4) obj.sub_field = readEmbeddedTypeContainer(pbf, pbf.readVarint() + pbf.pos);
+        else if (field === 5) obj.sub_sub_field = readEmbeddedTypeContainerInner(pbf, pbf.readVarint() + pbf.pos);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEmbeddedType(obj, pbf) {
     if (obj.value != null && obj.value !== "test") pbf.writeStringField(1, obj.value);
@@ -13,21 +16,27 @@ export function writeEmbeddedType(obj, pbf) {
     if (obj.sub_sub_field) pbf.writeMessage(5, writeEmbeddedTypeContainerInner, obj.sub_sub_field);
 }
 
-export function readEmbeddedTypeContainer(pbf, end) {
-    return pbf.readFields(readEmbeddedTypeContainerField, {values: []}, end);
-}
-function readEmbeddedTypeContainerField(tag, obj, pbf) {
-    if (tag === 1) obj.values.push(readEmbeddedTypeContainerInner(pbf, pbf.readVarint() + pbf.pos));
+export function readEmbeddedTypeContainer(pbf, end = pbf.length) {
+    const obj = {values: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.values.push(readEmbeddedTypeContainerInner(pbf, pbf.readVarint() + pbf.pos));
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEmbeddedTypeContainer(obj, pbf) {
     if (obj.values) for (const item of obj.values) pbf.writeMessage(1, writeEmbeddedTypeContainerInner, item);
 }
 
-export function readEmbeddedTypeContainerInner(pbf, end) {
-    return pbf.readFields(readEmbeddedTypeContainerInnerField, {value: ""}, end);
-}
-function readEmbeddedTypeContainerInnerField(tag, obj, pbf) {
-    if (tag === 1) obj.value = pbf.readString();
+export function readEmbeddedTypeContainerInner(pbf, end = pbf.length) {
+    const obj = {value: ""};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.value = pbf.readString();
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEmbeddedTypeContainerInner(obj, pbf) {
     if (obj.value) pbf.writeStringField(1, obj.value);

--- a/test/fixtures/map.js
+++ b/test/fixtures/map.js
@@ -1,34 +1,43 @@
 
-export function readEnvelope(pbf, end) {
-    return pbf.readFields(readEnvelopeField, {kv: {}, kn: {}}, end);
-}
-function readEnvelopeField(tag, obj, pbf) {
-    if (tag === 1) { const {key, value} = readEnvelope_FieldEntry1(pbf, pbf.readVarint() + pbf.pos); obj.kv[key] = value; }
-    else if (tag === 2) { const {key, value} = readEnvelope_FieldEntry2(pbf, pbf.readVarint() + pbf.pos); obj.kn[key] = value; }
+export function readEnvelope(pbf, end = pbf.length) {
+    const obj = {kv: {}, kn: {}};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) { const {key, value} = readEnvelope_FieldEntry1(pbf, pbf.readVarint() + pbf.pos); obj.kv[key] = value; }
+        else if (field === 2) { const {key, value} = readEnvelope_FieldEntry2(pbf, pbf.readVarint() + pbf.pos); obj.kn[key] = value; }
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEnvelope(obj, pbf) {
     if (obj.kv) for (const key of Object.keys(obj.kv)) pbf.writeMessage(1, writeEnvelope_FieldEntry1, {key, value: obj.kv[key]});
     if (obj.kn) for (const key of Object.keys(obj.kn)) pbf.writeMessage(2, writeEnvelope_FieldEntry2, {key, value: obj.kn[key]});
 }
 
-export function readEnvelope_FieldEntry1(pbf, end) {
-    return pbf.readFields(readEnvelope_FieldEntry1Field, {key: "", value: ""}, end);
-}
-function readEnvelope_FieldEntry1Field(tag, obj, pbf) {
-    if (tag === 1) obj.key = pbf.readString();
-    else if (tag === 2) obj.value = pbf.readString();
+export function readEnvelope_FieldEntry1(pbf, end = pbf.length) {
+    const obj = {key: "", value: ""};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.key = pbf.readString();
+        else if (field === 2) obj.value = pbf.readString();
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEnvelope_FieldEntry1(obj, pbf) {
     if (obj.key) pbf.writeStringField(1, obj.key);
     if (obj.value) pbf.writeStringField(2, obj.value);
 }
 
-export function readEnvelope_FieldEntry2(pbf, end) {
-    return pbf.readFields(readEnvelope_FieldEntry2Field, {key: "", value: 0}, end);
-}
-function readEnvelope_FieldEntry2Field(tag, obj, pbf) {
-    if (tag === 1) obj.key = pbf.readString();
-    else if (tag === 2) obj.value = pbf.readVarint(true);
+export function readEnvelope_FieldEntry2(pbf, end = pbf.length) {
+    const obj = {key: "", value: 0};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.key = pbf.readString();
+        else if (field === 2) obj.value = pbf.readVarint(true);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEnvelope_FieldEntry2(obj, pbf) {
     if (obj.key) pbf.writeStringField(1, obj.key);

--- a/test/fixtures/map.js
+++ b/test/fixtures/map.js
@@ -3,18 +3,18 @@ export function readEnvelope(pbf, end = pbf.length) {
     const obj = {kv: {}, kn: {}};
     while (pbf.pos < end) {
         const tag = pbf.readVarint(), field = tag >>> 3;
-        if (field === 1) { const {key, value} = readEnvelope_FieldEntry1(pbf, pbf.readVarint() + pbf.pos); obj.kv[key] = value; }
-        else if (field === 2) { const {key, value} = readEnvelope_FieldEntry2(pbf, pbf.readVarint() + pbf.pos); obj.kn[key] = value; }
+        if (field === 1) { const {key, value} = readEnvelopeKvEntry(pbf, pbf.readVarint() + pbf.pos); obj.kv[key] = value; }
+        else if (field === 2) { const {key, value} = readEnvelopeKnEntry(pbf, pbf.readVarint() + pbf.pos); obj.kn[key] = value; }
         else pbf.skip(tag);
     }
     return obj;
 }
 export function writeEnvelope(obj, pbf) {
-    if (obj.kv) for (const key of Object.keys(obj.kv)) pbf.writeMessage(1, writeEnvelope_FieldEntry1, {key, value: obj.kv[key]});
-    if (obj.kn) for (const key of Object.keys(obj.kn)) pbf.writeMessage(2, writeEnvelope_FieldEntry2, {key, value: obj.kn[key]});
+    if (obj.kv) for (const key of Object.keys(obj.kv)) pbf.writeMessage(1, writeEnvelopeKvEntry, {key, value: obj.kv[key]});
+    if (obj.kn) for (const key of Object.keys(obj.kn)) pbf.writeMessage(2, writeEnvelopeKnEntry, {key, value: obj.kn[key]});
 }
 
-export function readEnvelope_FieldEntry1(pbf, end = pbf.length) {
+export function readEnvelopeKvEntry(pbf, end = pbf.length) {
     const obj = {key: "", value: ""};
     while (pbf.pos < end) {
         const tag = pbf.readVarint(), field = tag >>> 3;
@@ -24,12 +24,12 @@ export function readEnvelope_FieldEntry1(pbf, end = pbf.length) {
     }
     return obj;
 }
-export function writeEnvelope_FieldEntry1(obj, pbf) {
+export function writeEnvelopeKvEntry(obj, pbf) {
     if (obj.key) pbf.writeStringField(1, obj.key);
     if (obj.value) pbf.writeStringField(2, obj.value);
 }
 
-export function readEnvelope_FieldEntry2(pbf, end = pbf.length) {
+export function readEnvelopeKnEntry(pbf, end = pbf.length) {
     const obj = {key: "", value: 0};
     while (pbf.pos < end) {
         const tag = pbf.readVarint(), field = tag >>> 3;
@@ -39,7 +39,7 @@ export function readEnvelope_FieldEntry2(pbf, end = pbf.length) {
     }
     return obj;
 }
-export function writeEnvelope_FieldEntry2(obj, pbf) {
+export function writeEnvelopeKnEntry(obj, pbf) {
     if (obj.key) pbf.writeStringField(1, obj.key);
     if (obj.value) pbf.writeVarintField(2, obj.value);
 }

--- a/test/fixtures/map_collision.js
+++ b/test/fixtures/map_collision.js
@@ -1,0 +1,67 @@
+
+export function readEnvelope(pbf, end = pbf.length) {
+    const obj = {kv: {}, kn: {}, sibling: undefined, flag: 0};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) { const {key, value} = readEnvelopeKvEntry$(pbf, pbf.readVarint() + pbf.pos); obj.kv[key] = value; }
+        else if (field === 2) { const {key, value} = readEnvelopeKnEntry$(pbf, pbf.readVarint() + pbf.pos); obj.kn[key] = value; }
+        else if (field === 3) obj.sibling = readEnvelopeKvEntry(pbf, pbf.readVarint() + pbf.pos);
+        else if (field === 4) obj.flag = pbf.readVarint();
+        else pbf.skip(tag);
+    }
+    return obj;
+}
+export function writeEnvelope(obj, pbf) {
+    if (obj.kv) for (const key of Object.keys(obj.kv)) pbf.writeMessage(1, writeEnvelopeKvEntry$, {key, value: obj.kv[key]});
+    if (obj.kn) for (const key of Object.keys(obj.kn)) pbf.writeMessage(2, writeEnvelopeKnEntry$, {key, value: obj.kn[key]});
+    if (obj.sibling) pbf.writeMessage(3, writeEnvelopeKvEntry, obj.sibling);
+    if (obj.flag) pbf.writeVarintField(4, obj.flag);
+}
+
+export const EnvelopeKnEntry = {
+    "ZERO": 0,
+    "ONE": 1
+};
+
+export function readEnvelopeKvEntry(pbf, end = pbf.length) {
+    const obj = {marker: 0};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.marker = pbf.readVarint(true);
+        else pbf.skip(tag);
+    }
+    return obj;
+}
+export function writeEnvelopeKvEntry(obj, pbf) {
+    if (obj.marker) pbf.writeVarintField(1, obj.marker);
+}
+
+export function readEnvelopeKvEntry$(pbf, end = pbf.length) {
+    const obj = {key: "", value: ""};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.key = pbf.readString();
+        else if (field === 2) obj.value = pbf.readString();
+        else pbf.skip(tag);
+    }
+    return obj;
+}
+export function writeEnvelopeKvEntry$(obj, pbf) {
+    if (obj.key) pbf.writeStringField(1, obj.key);
+    if (obj.value) pbf.writeStringField(2, obj.value);
+}
+
+export function readEnvelopeKnEntry$(pbf, end = pbf.length) {
+    const obj = {key: "", value: 0};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.key = pbf.readString();
+        else if (field === 2) obj.value = pbf.readVarint(true);
+        else pbf.skip(tag);
+    }
+    return obj;
+}
+export function writeEnvelopeKnEntry$(obj, pbf) {
+    if (obj.key) pbf.writeStringField(1, obj.key);
+    if (obj.value) pbf.writeVarintField(2, obj.value);
+}

--- a/test/fixtures/map_collision.proto
+++ b/test/fixtures/map_collision.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+message Envelope {
+    message KvEntry {
+        int32 marker = 1;
+    }
+    enum KnEntry {
+        ZERO = 0;
+        ONE = 1;
+    }
+    map<string, string> kv = 1;
+    map<string, int32> kn = 2;
+    Envelope.KvEntry sibling = 3;
+    Envelope.KnEntry flag = 4;
+}

--- a/test/fixtures/oneof.js
+++ b/test/fixtures/oneof.js
@@ -1,12 +1,15 @@
 
-export function readEnvelope(pbf, end) {
-    return pbf.readFields(readEnvelopeField, {id: 0, int: 0, value: undefined, float: 0, string: ""}, end);
-}
-function readEnvelopeField(tag, obj, pbf) {
-    if (tag === 1) obj.id = pbf.readVarint(true);
-    else if (tag === 2) { obj.int = pbf.readVarint(true); obj.value = "int"; }
-    else if (tag === 3) { obj.float = pbf.readFloat(); obj.value = "float"; }
-    else if (tag === 4) { obj.string = pbf.readString(); obj.value = "string"; }
+export function readEnvelope(pbf, end = pbf.length) {
+    const obj = {id: 0, int: 0, value: undefined, float: 0, string: ""};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.id = pbf.readVarint(true);
+        else if (field === 2) { obj.int = pbf.readVarint(true); obj.value = "int"; }
+        else if (field === 3) { obj.float = pbf.readFloat(); obj.value = "float"; }
+        else if (field === 4) { obj.string = pbf.readString(); obj.value = "string"; }
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEnvelope(obj, pbf) {
     if (obj.id) pbf.writeVarintField(1, obj.id);

--- a/test/fixtures/packed.js
+++ b/test/fixtures/packed.js
@@ -1,34 +1,43 @@
 
-export function readNotPacked(pbf, end) {
-    return pbf.readFields(readNotPackedField, {value: [], types: []}, end);
-}
-function readNotPackedField(tag, obj, pbf) {
-    if (tag === 1) pbf.readPackedVarint(obj.value, true);
-    else if (tag === 2) pbf.readPackedVarint(obj.types, true);
+export function readNotPacked(pbf, end = pbf.length) {
+    const obj = {value: [], types: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 1) pbf.readPackedVarint(obj.value, true);
+        else if (field === 2) pbf.readPackedVarint(obj.types, true);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeNotPacked(obj, pbf) {
     if (obj.value) for (const item of obj.value) pbf.writeVarintField(1, item);
     if (obj.types) for (const item of obj.types) pbf.writeVarintField(2, item);
 }
 
-export function readFalsePacked(pbf, end) {
-    return pbf.readFields(readFalsePackedField, {value: [], types: []}, end);
-}
-function readFalsePackedField(tag, obj, pbf) {
-    if (tag === 1) pbf.readPackedVarint(obj.value, true);
-    else if (tag === 2) pbf.readPackedVarint(obj.types, true);
+export function readFalsePacked(pbf, end = pbf.length) {
+    const obj = {value: [], types: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 1) pbf.readPackedVarint(obj.value, true);
+        else if (field === 2) pbf.readPackedVarint(obj.types, true);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeFalsePacked(obj, pbf) {
     if (obj.value) for (const item of obj.value) pbf.writeVarintField(1, item);
     if (obj.types) for (const item of obj.types) pbf.writeVarintField(2, item);
 }
 
-export function readPacked(pbf, end) {
-    return pbf.readFields(readPackedField, {value: [], types: []}, end);
-}
-function readPackedField(tag, obj, pbf) {
-    if (tag === 1) pbf.readPackedVarint(obj.value, true);
-    else if (tag === 2) pbf.readPackedVarint(obj.types, true);
+export function readPacked(pbf, end = pbf.length) {
+    const obj = {value: [], types: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 1) pbf.readPackedVarint(obj.value, true);
+        else if (field === 2) pbf.readPackedVarint(obj.types, true);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writePacked(obj, pbf) {
     if (obj.value) pbf.writePackedVarint(1, obj.value);

--- a/test/fixtures/packed_proto3.js
+++ b/test/fixtures/packed_proto3.js
@@ -4,35 +4,44 @@ export const MessageType = {
     "GREETING": 1
 };
 
-export function readNotPacked(pbf, end) {
-    return pbf.readFields(readNotPackedField, {value: [], types: []}, end);
-}
-function readNotPackedField(tag, obj, pbf) {
-    if (tag === 1) pbf.readPackedVarint(obj.value, true);
-    else if (tag === 2) pbf.readPackedVarint(obj.types);
+export function readNotPacked(pbf, end = pbf.length) {
+    const obj = {value: [], types: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 1) pbf.readPackedVarint(obj.value, true);
+        else if (field === 2) pbf.readPackedVarint(obj.types);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeNotPacked(obj, pbf) {
     if (obj.value) pbf.writePackedVarint(1, obj.value);
     if (obj.types) pbf.writePackedVarint(2, obj.types);
 }
 
-export function readFalsePacked(pbf, end) {
-    return pbf.readFields(readFalsePackedField, {value: [], types: []}, end);
-}
-function readFalsePackedField(tag, obj, pbf) {
-    if (tag === 1) pbf.readPackedVarint(obj.value, true);
-    else if (tag === 2) pbf.readPackedVarint(obj.types);
+export function readFalsePacked(pbf, end = pbf.length) {
+    const obj = {value: [], types: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 1) pbf.readPackedVarint(obj.value, true);
+        else if (field === 2) pbf.readPackedVarint(obj.types);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeFalsePacked(obj, pbf) {
     if (obj.value) for (const item of obj.value) pbf.writeVarintField(1, item);
     if (obj.types) for (const item of obj.types) pbf.writeVarintField(2, item);
 }
 
-export function readPacked(pbf, end) {
-    return pbf.readFields(readPackedField, {value: []}, end);
-}
-function readPackedField(tag, obj, pbf) {
-    if (tag === 16) pbf.readPackedVarint(obj.value, true);
+export function readPacked(pbf, end = pbf.length) {
+    const obj = {value: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 16) pbf.readPackedVarint(obj.value, true);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writePacked(obj, pbf) {
     if (obj.value) pbf.writePackedVarint(16, obj.value);

--- a/test/fixtures/packed_proto3.js
+++ b/test/fixtures/packed_proto3.js
@@ -46,3 +46,16 @@ export function readPacked(pbf, end = pbf.length) {
 export function writePacked(obj, pbf) {
     if (obj.value) pbf.writePackedVarint(16, obj.value);
 }
+
+export function readPackedFixed(pbf, end = pbf.length) {
+    const obj = {value: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 1) pbf.readPackedSFixed64(obj.value);
+        else pbf.skip(tag);
+    }
+    return obj;
+}
+export function writePackedFixed(obj, pbf) {
+    if (obj.value) pbf.writePackedSFixed64(1, obj.value);
+}

--- a/test/fixtures/packed_proto3.proto
+++ b/test/fixtures/packed_proto3.proto
@@ -20,3 +20,6 @@ message FalsePacked {
 message Packed {
   repeated int32 value = 16;
 }
+message PackedFixed {
+  repeated sfixed64 value = 1;
+}

--- a/test/fixtures/type_string.js
+++ b/test/fixtures/type_string.js
@@ -1,14 +1,17 @@
 
-export function readTypeString(pbf, end) {
-    return pbf.readFields(readTypeStringField, {int: "0", long: "0", boolVal: false, float: "0", default_implicit: "0", default_explicit: "42"}, end);
-}
-function readTypeStringField(tag, obj, pbf) {
-    if (tag === 1) obj.int = pbf.readVarint(true).toString();
-    else if (tag === 2) obj.long = pbf.readVarint(true).toString();
-    else if (tag === 3) obj.boolVal = pbf.readBoolean();
-    else if (tag === 4) obj.float = pbf.readFloat().toString();
-    else if (tag === 5) obj.default_implicit = pbf.readVarint(true).toString();
-    else if (tag === 6) obj.default_explicit = pbf.readVarint(true).toString();
+export function readTypeString(pbf, end = pbf.length) {
+    const obj = {int: "0", long: "0", boolVal: false, float: "0", default_implicit: "0", default_explicit: "42"};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.int = pbf.readVarint(true).toString();
+        else if (field === 2) obj.long = pbf.readVarint(true).toString();
+        else if (field === 3) obj.boolVal = pbf.readBoolean();
+        else if (field === 4) obj.float = pbf.readFloat().toString();
+        else if (field === 5) obj.default_implicit = pbf.readVarint(true).toString();
+        else if (field === 6) obj.default_explicit = pbf.readVarint(true).toString();
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeTypeString(obj, pbf) {
     if (obj.int != null && obj.int !== "0") pbf.writeVarintField(1, parseInt(obj.int, 10));
@@ -19,14 +22,17 @@ export function writeTypeString(obj, pbf) {
     if (obj.default_explicit != null && obj.default_explicit !== "42") pbf.writeVarintField(6, parseInt(obj.default_explicit, 10));
 }
 
-export function readTypeNotString(pbf, end) {
-    return pbf.readFields(readTypeNotStringField, {int: 0, long: 0, boolVal: false, float: 0}, end);
-}
-function readTypeNotStringField(tag, obj, pbf) {
-    if (tag === 1) obj.int = pbf.readVarint(true);
-    else if (tag === 2) obj.long = pbf.readVarint(true);
-    else if (tag === 3) obj.boolVal = pbf.readBoolean();
-    else if (tag === 4) obj.float = pbf.readFloat();
+export function readTypeNotString(pbf, end = pbf.length) {
+    const obj = {int: 0, long: 0, boolVal: false, float: 0};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.int = pbf.readVarint(true);
+        else if (field === 2) obj.long = pbf.readVarint(true);
+        else if (field === 3) obj.boolVal = pbf.readBoolean();
+        else if (field === 4) obj.float = pbf.readFloat();
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeTypeNotString(obj, pbf) {
     if (obj.int) pbf.writeVarintField(1, obj.int);

--- a/test/fixtures/varint.js
+++ b/test/fixtures/varint.js
@@ -1,12 +1,15 @@
 
-export function readEnvelope(pbf, end) {
-    return pbf.readFields(readEnvelopeField, {int: 0, uint: 0, long: 0, ulong: 0}, end);
-}
-function readEnvelopeField(tag, obj, pbf) {
-    if (tag === 1) obj.int = pbf.readVarint(true);
-    else if (tag === 2) obj.uint = pbf.readVarint();
-    else if (tag === 3) obj.long = pbf.readVarint(true);
-    else if (tag === 4) obj.ulong = pbf.readVarint();
+export function readEnvelope(pbf, end = pbf.length) {
+    const obj = {int: 0, uint: 0, long: 0, ulong: 0};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.int = pbf.readVarint(true);
+        else if (field === 2) obj.uint = pbf.readVarint();
+        else if (field === 3) obj.long = pbf.readVarint(true);
+        else if (field === 4) obj.ulong = pbf.readVarint();
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeEnvelope(obj, pbf) {
     if (obj.int) pbf.writeVarintField(1, obj.int);

--- a/test/fixtures/vector_tile.js
+++ b/test/fixtures/vector_tile.js
@@ -1,9 +1,12 @@
 
-export function readTile(pbf, end) {
-    return pbf.readFields(readTileField, {layers: []}, end);
-}
-function readTileField(tag, obj, pbf) {
-    if (tag === 3) obj.layers.push(readTileLayer(pbf, pbf.readVarint() + pbf.pos));
+export function readTile(pbf, end = pbf.length) {
+    const obj = {layers: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 3) obj.layers.push(readTileLayer(pbf, pbf.readVarint() + pbf.pos));
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeTile(obj, pbf) {
     if (obj.layers) for (const item of obj.layers) pbf.writeMessage(3, writeTileLayer, item);
@@ -16,17 +19,20 @@ export const TileGeomType = {
     "POLYGON": 3
 };
 
-export function readTileValue(pbf, end) {
-    return pbf.readFields(readTileValueField, {string_value: "", float_value: 0, double_value: 0, int_value: 0, uint_value: 0, sint_value: 0, bool_value: false}, end);
-}
-function readTileValueField(tag, obj, pbf) {
-    if (tag === 1) obj.string_value = pbf.readString();
-    else if (tag === 2) obj.float_value = pbf.readFloat();
-    else if (tag === 3) obj.double_value = pbf.readDouble();
-    else if (tag === 4) obj.int_value = pbf.readVarint(true);
-    else if (tag === 5) obj.uint_value = pbf.readVarint();
-    else if (tag === 6) obj.sint_value = pbf.readSVarint();
-    else if (tag === 7) obj.bool_value = pbf.readBoolean();
+export function readTileValue(pbf, end = pbf.length) {
+    const obj = {string_value: "", float_value: 0, double_value: 0, int_value: 0, uint_value: 0, sint_value: 0, bool_value: false};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 1) obj.string_value = pbf.readString();
+        else if (field === 2) obj.float_value = pbf.readFloat();
+        else if (field === 3) obj.double_value = pbf.readDouble();
+        else if (field === 4) obj.int_value = pbf.readVarint(true);
+        else if (field === 5) obj.uint_value = pbf.readVarint();
+        else if (field === 6) obj.sint_value = pbf.readSVarint();
+        else if (field === 7) obj.bool_value = pbf.readBoolean();
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeTileValue(obj, pbf) {
     if (obj.string_value) pbf.writeStringField(1, obj.string_value);
@@ -38,14 +44,17 @@ export function writeTileValue(obj, pbf) {
     if (obj.bool_value) pbf.writeBooleanField(7, obj.bool_value);
 }
 
-export function readTileFeature(pbf, end) {
-    return pbf.readFields(readTileFeatureField, {id: 0, tags: [], type: 0, geometry: []}, end);
-}
-function readTileFeatureField(tag, obj, pbf) {
-    if (tag === 1) obj.id = pbf.readVarint();
-    else if (tag === 2) pbf.readPackedVarint(obj.tags);
-    else if (tag === 3) obj.type = pbf.readVarint();
-    else if (tag === 4) pbf.readPackedVarint(obj.geometry);
+export function readTileFeature(pbf, end = pbf.length) {
+    const obj = {id: 0, tags: [], type: 0, geometry: []};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3; pbf.type = tag & 7;
+        if (field === 1) obj.id = pbf.readVarint();
+        else if (field === 2) pbf.readPackedVarint(obj.tags);
+        else if (field === 3) obj.type = pbf.readVarint();
+        else if (field === 4) pbf.readPackedVarint(obj.geometry);
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeTileFeature(obj, pbf) {
     if (obj.id) pbf.writeVarintField(1, obj.id);
@@ -54,16 +63,19 @@ export function writeTileFeature(obj, pbf) {
     if (obj.geometry) pbf.writePackedVarint(4, obj.geometry);
 }
 
-export function readTileLayer(pbf, end) {
-    return pbf.readFields(readTileLayerField, {version: 1, name: "", features: [], keys: [], values: [], extent: 4096}, end);
-}
-function readTileLayerField(tag, obj, pbf) {
-    if (tag === 15) obj.version = pbf.readVarint();
-    else if (tag === 1) obj.name = pbf.readString();
-    else if (tag === 2) obj.features.push(readTileFeature(pbf, pbf.readVarint() + pbf.pos));
-    else if (tag === 3) obj.keys.push(pbf.readString());
-    else if (tag === 4) obj.values.push(readTileValue(pbf, pbf.readVarint() + pbf.pos));
-    else if (tag === 5) obj.extent = pbf.readVarint();
+export function readTileLayer(pbf, end = pbf.length) {
+    const obj = {version: 1, name: "", features: [], keys: [], values: [], extent: 4096};
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint(), field = tag >>> 3;
+        if (field === 15) obj.version = pbf.readVarint();
+        else if (field === 1) obj.name = pbf.readString();
+        else if (field === 2) obj.features.push(readTileFeature(pbf, pbf.readVarint() + pbf.pos));
+        else if (field === 3) obj.keys.push(pbf.readString());
+        else if (field === 4) obj.values.push(readTileValue(pbf, pbf.readVarint() + pbf.pos));
+        else if (field === 5) obj.extent = pbf.readVarint();
+        else pbf.skip(tag);
+    }
+    return obj;
 }
 export function writeTileLayer(obj, pbf) {
     if (obj.version != null && obj.version !== 1) pbf.writeVarintField(15, obj.version);

--- a/test/pbf.test.js
+++ b/test/pbf.test.js
@@ -82,12 +82,6 @@ test('readVarint signed', () => {
     assert.equal(buf.readVarint(true), 200);
 });
 
-test('readVarint64 (compatibility)', () => {
-    const bytes = [0xc8, 0xe8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01];
-    const buf = new PbfReader(Buffer.from(bytes));
-    assert.equal(buf.readVarint64(), -3000);
-});
-
 test('readVarint & writeVarint handle really big numbers', () => {
     const writer = new PbfWriter();
     const bigNum1 = Math.pow(2, 60);

--- a/test/pbf.test.js
+++ b/test/pbf.test.js
@@ -1,5 +1,5 @@
 
-import Pbf from '../index.js';
+import {PbfReader, PbfWriter} from '../index.js';
 import fs from 'fs';
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -13,11 +13,12 @@ function toArray(buf) {
 }
 
 test('initialization', () => {
-    assert.doesNotThrow(() => new Pbf(Buffer.alloc(0)));
+    assert.doesNotThrow(() => new PbfReader(Buffer.alloc(0)));
+    assert.doesNotThrow(() => new PbfWriter());
 });
 
 test('realloc', () => {
-    const buf = new Pbf(Buffer.alloc(0));
+    const buf = new PbfWriter();
     buf.realloc(5);
     assert.ok(buf.length >= 5);
     buf.realloc(25);
@@ -32,70 +33,70 @@ const testNumbers = [1, 0, 0, 4, 14, 23, 40, 86, 127, 141, 113, 925, 258, 1105, 
     301300890730496, 1310140661760000, 2883205519638528, 2690669862715392, 3319292539961344];
 
 test('readVarint & writeVarint', () => {
-    const buf = new Pbf(Buffer.alloc(0));
+    const writer = new PbfWriter();
 
     for (let i = 0; i < testNumbers.length; i++) {
-        buf.writeVarint(testNumbers[i]);
-        if (testNumbers[i]) buf.writeVarint(-testNumbers[i]);
+        writer.writeVarint(testNumbers[i]);
+        if (testNumbers[i]) writer.writeVarint(-testNumbers[i]);
     }
-    const len = buf.finish().length;
-    assert.equal(len, 839);
-    buf.finish();
+    const buf = writer.finish();
+    assert.equal(buf.length, 839);
 
+    const reader = new PbfReader(buf);
     let i = 0;
-    while (buf.pos < len) {
-        assert.equal(buf.readVarint(), testNumbers[i]);
-        if (testNumbers[i]) assert.equal(buf.readVarint(true), -testNumbers[i]);
+    while (reader.pos < buf.length) {
+        assert.equal(reader.readVarint(), testNumbers[i]);
+        if (testNumbers[i]) assert.equal(reader.readVarint(true), -testNumbers[i]);
         i++;
     }
 });
 
 test('writeVarint writes 0 for NaN', () => {
     const buf = Buffer.alloc(16);
-    const pbf = new Pbf(buf);
+    const writer = new PbfWriter(buf);
 
     // Initialize buffer to ensure consistent tests
     buf.write('0123456789abcdef', 0);
 
-    pbf.writeVarint('not a number');
-    pbf.writeVarint(NaN);
-    pbf.writeVarint(50);
-    pbf.finish();
+    writer.writeVarint('not a number');
+    writer.writeVarint(NaN);
+    writer.writeVarint(50);
 
-    assert.equal(pbf.readVarint(), 0);
-    assert.equal(pbf.readVarint(), 0);
-    assert.equal(pbf.readVarint(), 50);
+    const reader = new PbfReader(writer.finish());
+    assert.equal(reader.readVarint(), 0);
+    assert.equal(reader.readVarint(), 0);
+    assert.equal(reader.readVarint(), 50);
 });
 
 test('readVarint signed', () => {
     let bytes = [0xc8, 0xe8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01];
-    let buf = new Pbf(Buffer.from(bytes));
+    let buf = new PbfReader(Buffer.from(bytes));
     assert.equal(buf.readVarint(true), -3000);
 
     bytes = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01];
-    buf = new Pbf(Buffer.from(bytes));
+    buf = new PbfReader(Buffer.from(bytes));
     assert.equal(buf.readVarint(true), -1);
 
     bytes = [0xc8, 0x01];
-    buf = new Pbf(Buffer.from(bytes));
+    buf = new PbfReader(Buffer.from(bytes));
     assert.equal(buf.readVarint(true), 200);
 });
 
 test('readVarint64 (compatibility)', () => {
     const bytes = [0xc8, 0xe8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01];
-    const buf = new Pbf(Buffer.from(bytes));
+    const buf = new PbfReader(Buffer.from(bytes));
     assert.equal(buf.readVarint64(), -3000);
 });
 
 test('readVarint & writeVarint handle really big numbers', () => {
-    const buf = new Pbf();
+    const writer = new PbfWriter();
     const bigNum1 = Math.pow(2, 60);
     const bigNum2 = Math.pow(2, 63);
-    buf.writeVarint(bigNum1);
-    buf.writeVarint(bigNum2);
-    buf.finish();
-    assert.equal(buf.readVarint(), bigNum1);
-    assert.equal(buf.readVarint(), bigNum2);
+    writer.writeVarint(bigNum1);
+    writer.writeVarint(bigNum2);
+    const reader = new PbfReader(writer.finish());
+    assert.equal(reader.readVarint(), bigNum1);
+    assert.equal(reader.readVarint(), bigNum2);
 });
 
 const testSigned = [0, 1, 2, 0, 2, -1, 11, 18, -17, 145, 369, 891, -1859, -798, 2780, -13107, 12589, -16433, 21140, 148023,
@@ -105,23 +106,23 @@ const testSigned = [0, 1, 2, 0, 2, -1, 11, 18, -17, 145, 369, 891, -1859, -798, 
     19583051038720, 83969719009280, 52578722775040, 416482297118720, 1981092523409408, -389256637841408];
 
 test('readSVarint & writeSVarint', () => {
-    const buf = new Pbf(Buffer.alloc(0));
+    const writer = new PbfWriter();
 
     for (let i = 0; i < testSigned.length; i++) {
-        buf.writeSVarint(testSigned[i]);
+        writer.writeSVarint(testSigned[i]);
     }
-    const len = buf.finish().length;
-    assert.equal(len, 224);
-    buf.finish();
+    const buf = writer.finish();
+    assert.equal(buf.length, 224);
 
+    const reader = new PbfReader(buf);
     let i = 0;
-    while (buf.pos < len) {
-        assert.equal(buf.readSVarint(), testSigned[i++]);
+    while (reader.pos < buf.length) {
+        assert.equal(reader.readSVarint(), testSigned[i++]);
     }
 });
 
 test('writeVarint throws error on a number that is too big', () => {
-    const buf = new Pbf(Buffer.alloc(0));
+    const buf = new PbfWriter();
 
     assert.throws(() => {
         buf.writeVarint(29234322996241367000012); // eslint-disable-line
@@ -133,37 +134,37 @@ test('writeVarint throws error on a number that is too big', () => {
 });
 
 test('readVarint throws error on a number that is longer than 10 bytes', () => {
-    const buf = new Pbf(Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
+    const buf = new PbfReader(Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
     assert.throws(() => {
         buf.readVarint();
     });
 });
 
 test('readBoolean & writeBoolean', () => {
-    const buf = new Pbf();
-    buf.writeBoolean(true);
-    buf.writeBoolean(false);
-    buf.finish();
-    assert.equal(buf.readBoolean(), true);
-    assert.equal(buf.readBoolean(), false);
+    const writer = new PbfWriter();
+    writer.writeBoolean(true);
+    writer.writeBoolean(false);
+    const reader = new PbfReader(writer.finish());
+    assert.equal(reader.readBoolean(), true);
+    assert.equal(reader.readBoolean(), false);
 });
 
 test('readBytes', () => {
-    const buf = new Pbf([8, 1, 2, 3, 4, 5, 6, 7, 8]);
+    const buf = new PbfReader(new Uint8Array([8, 1, 2, 3, 4, 5, 6, 7, 8]));
     assert.deepEqual(toArray(buf.readBytes()), [1, 2, 3, 4, 5, 6, 7, 8]);
 });
 
 test('writeBytes', () => {
-    const buf = new Pbf();
-    buf.writeBytes([1, 2, 3, 4, 5, 6, 7, 8]);
-    const bytes = buf.finish();
+    const writer = new PbfWriter();
+    writer.writeBytes(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    const bytes = writer.finish();
     assert.deepEqual(toArray(bytes), [8, 1, 2, 3, 4, 5, 6, 7, 8]);
 });
 
 test('readDouble', () => {
     const buffer = Buffer.alloc(8);
     buffer.writeDoubleLE(12345.6789012345, 0);
-    const buf = new Pbf(buffer);
+    const buf = new PbfReader(buffer);
     assert.equal(Math.round(buf.readDouble() * 1e10) / 1e10, 12345.6789012345);
 });
 
@@ -171,28 +172,28 @@ test('readPacked and writePacked', () => {
     const testNumbers2 = testNumbers.slice(0, 10);
 
     function testPacked(type) {
-        const buf = new Pbf();
-        buf[`writePacked${type}`](1, testNumbers2);
-        buf.finish();
-        buf.readFields((tag) => {
+        const writer = new PbfWriter();
+        writer[`writePacked${type}`](1, testNumbers2);
+        const reader = new PbfReader(writer.finish());
+        reader.readFields((tag) => {
             const arr = [];
-            buf[`readPacked${type}`](arr);
+            reader[`readPacked${type}`](arr);
             if (tag === 1) assert.deepEqual(arr, testNumbers2, `packed ${type}`);
             else assert.fail(`wrong tag encountered: ${tag}`);
         });
     }
 
     function testUnpacked(type) {
-        const buf = new Pbf();
+        const writer = new PbfWriter();
         const arr = [];
 
         testNumbers2.forEach((n) => {
-            buf[`write${type}Field`](1, n);
+            writer[`write${type}Field`](1, n);
         });
 
-        buf.finish();
-        buf.readFields(() => {
-            buf[`readPacked${type}`](arr);
+        const reader = new PbfReader(writer.finish());
+        reader.readFields(() => {
+            reader[`readPacked${type}`](arr);
         });
 
         assert.deepEqual(arr, testNumbers2, `packed ${type}`);
@@ -203,12 +204,12 @@ test('readPacked and writePacked', () => {
         testUnpacked(type);
     });
 
-    const buf = new Pbf();
-    buf.writePackedBoolean(1, testNumbers2);
-    buf.finish();
-    buf.readFields((tag) => {
+    const writer = new PbfWriter();
+    writer.writePackedBoolean(1, testNumbers2);
+    const reader = new PbfReader(writer.finish());
+    reader.readFields((tag) => {
         const arr = [];
-        buf.readPackedBoolean(arr);
+        reader.readPackedBoolean(arr);
         if (tag === 1) assert.deepEqual(arr,
             [true, false, false, true, true, true, true, true, true, true], 'packed Boolean');
         else assert.fail(`wrong tag encountered: ${tag}`);
@@ -216,60 +217,60 @@ test('readPacked and writePacked', () => {
 });
 
 test('writePacked skips empty arrays', () => {
-    const pbf = new Pbf();
+    const pbf = new PbfWriter();
     pbf.writePackedBoolean(1, []);
     const buf = pbf.finish();
     assert.equal(buf.length, 0);
 });
 
 test('writeDouble', () => {
-    const buf = new Pbf(Buffer.alloc(8));
-    buf.writeDouble(12345.6789012345);
-    buf.finish();
-    assert.equal(Math.round(buf.readDouble() * 1e10) / 1e10, 12345.6789012345);
+    const writer = new PbfWriter(Buffer.alloc(8));
+    writer.writeDouble(12345.6789012345);
+    const reader = new PbfReader(writer.finish());
+    assert.equal(Math.round(reader.readDouble() * 1e10) / 1e10, 12345.6789012345);
 });
 
 test('readFloat', () => {
     const buffer = Buffer.alloc(4);
     buffer.writeFloatLE(123.456, 0);
-    const buf = new Pbf(buffer);
+    const buf = new PbfReader(buffer);
     assert.equal(Math.round(1000 * buf.readFloat()) / 1000, 123.456);
 });
 
 test('writeFloat', () => {
-    const buf = new Pbf(Buffer.alloc(4));
-    buf.writeFloat(123.456);
-    buf.finish();
-    assert.equal(Math.round(1000 * buf.readFloat()) / 1000, 123.456);
+    const writer = new PbfWriter(Buffer.alloc(4));
+    writer.writeFloat(123.456);
+    const reader = new PbfReader(writer.finish());
+    assert.equal(Math.round(1000 * reader.readFloat()) / 1000, 123.456);
 });
 
 test('readFixed32', () => {
     const buffer = Buffer.alloc(16);
     buffer.writeUInt32LE(42, 0);
     buffer.writeUInt32LE(24, 4);
-    const buf = new Pbf(buffer);
+    const buf = new PbfReader(buffer);
     assert.equal(buf.readFixed32(), 42);
     assert.equal(buf.readFixed32(), 24);
 });
 
 test('writeFixed32', () => {
-    const buf = new Pbf(Buffer.alloc(16));
-    buf.writeFixed32(42);
-    buf.writeFixed32(24);
-    buf.finish();
-    assert.equal(buf.readFixed32(), 42);
-    assert.equal(buf.readFixed32(), 24);
+    const writer = new PbfWriter(Buffer.alloc(16));
+    writer.writeFixed32(42);
+    writer.writeFixed32(24);
+    const reader = new PbfReader(writer.finish());
+    assert.equal(reader.readFixed32(), 42);
+    assert.equal(reader.readFixed32(), 24);
 });
 
 test('readFixed64', () => {
-    const buf = new Pbf(Buffer.alloc(8));
-    buf.writeFixed64(102451124123);
-    buf.finish();
-    assert.deepEqual(buf.readFixed64(), 102451124123);
+    const writer = new PbfWriter(Buffer.alloc(8));
+    writer.writeFixed64(102451124123);
+    const reader = new PbfReader(writer.finish());
+    assert.deepEqual(reader.readFixed64(), 102451124123);
 });
 
 test('writeFixed64', () => {
-    const buf = new Pbf(Buffer.alloc(8));
+    const buf = new PbfWriter(Buffer.alloc(8));
     buf.writeFixed64(102451124123);
     assert.deepEqual(toArray(buf.buf), [155, 23, 144, 218, 23, 0, 0, 0]);
 });
@@ -278,62 +279,60 @@ test('readSFixed32', () => {
     const buffer = Buffer.alloc(16);
     buffer.writeInt32LE(4223, 0);
     buffer.writeInt32LE(-1231, 4);
-    const buf = new Pbf(buffer);
+    const buf = new PbfReader(buffer);
     assert.equal(buf.readSFixed32(), 4223);
     assert.equal(buf.readSFixed32(), -1231);
 });
 
 test('writeSFixed32', () => {
-    const buf = new Pbf(Buffer.alloc(16));
-    buf.writeSFixed32(4223);
-    buf.writeSFixed32(-1231);
-    buf.finish();
-    assert.equal(buf.readSFixed32(), 4223);
-    assert.equal(buf.readSFixed32(), -1231);
+    const writer = new PbfWriter(Buffer.alloc(16));
+    writer.writeSFixed32(4223);
+    writer.writeSFixed32(-1231);
+    const reader = new PbfReader(writer.finish());
+    assert.equal(reader.readSFixed32(), 4223);
+    assert.equal(reader.readSFixed32(), -1231);
 });
 
 test('readSFixed64', () => {
-    const buf = new Pbf(Buffer.alloc(8));
-    buf.writeSFixed64(-102451124123);
-    buf.finish();
-    assert.deepEqual(buf.readSFixed64(), -102451124123);
+    const writer = new PbfWriter(Buffer.alloc(8));
+    writer.writeSFixed64(-102451124123);
+    const reader = new PbfReader(writer.finish());
+    assert.deepEqual(reader.readSFixed64(), -102451124123);
 });
 
 test('writeSFixed64', () => {
-    const buf = new Pbf(Buffer.alloc(8));
+    const buf = new PbfWriter(Buffer.alloc(8));
     buf.writeSFixed64(-102451124123);
     assert.deepEqual(toArray(buf.buf), [101, 232, 111, 37, 232, 255, 255, 255]);
 });
 
 test('writeString & readString', () => {
-    const buf = new Pbf();
-    buf.writeString('Привет 李小龙');
-    const bytes = buf.finish();
+    const writer = new PbfWriter();
+    writer.writeString('Привет 李小龙');
+    const bytes = writer.finish();
     assert.deepEqual(bytes, new Uint8Array([22, 208, 159, 209, 128, 208, 184, 208, 178, 208, 181, 209, 130, 32, 230, 157, 142, 229, 176, 143, 233, 190, 153]));
-    assert.equal(buf.readString(), 'Привет 李小龙');
+    assert.equal(new PbfReader(bytes).readString(), 'Привет 李小龙');
 });
 
 test('writeString & readString longer', () => {
     const str = '{"Feature":"http://example.com/vocab#Feature","datetime":{"@id":"http://www.w3.org/2006/time#inXSDDateTime","@type":"http://www.w3.org/2001/XMLSchema#dateTime"},"when":"http://example.com/vocab#when"}';
-    const buf = new Pbf();
-    buf.writeString(str);
-    buf.finish();
-    assert.equal(buf.readString(), str);
+    const writer = new PbfWriter();
+    writer.writeString(str);
+    assert.equal(new PbfReader(writer.finish()).readString(), str);
 });
 
 test('more complicated utf8', () => {
-    const buf = new Pbf();
+    const writer = new PbfWriter();
     // crazy test from github.com/mathiasbynens/utf8.js
-    const str = '\uDC00\uDC00\uDC00\uDC00A\uDC00\uD834\uDF06\uDC00\uDEEE\uDFFF\uD800\uDC00\uD800\uD800\uD800\uD800A' +
-        '\uD800\uD834\uDF06';
-    buf.writeString(str);
-    buf.finish();
-    const str2 = buf.readString();
+    const str = '\uDC00\uDC00\uDC00\uDC00A\uDC00𝌆\uDC00\uDEEE\uDFFF𐀀\uD800\uD800\uD800\uD800A' +
+        '\uD800𝌆';
+    writer.writeString(str);
+    const str2 = new PbfReader(writer.finish()).readString();
     assert.deepEqual(new Uint8Array(str2), new Uint8Array(str));
 });
 
 test('readFields', () => {
-    const buf = new Pbf(fs.readFileSync(new URL('fixtures/12665.vector.pbf', import.meta.url)));
+    const buf = new PbfReader(fs.readFileSync(new URL('fixtures/12665.vector.pbf', import.meta.url)));
     const layerOffsets = [];
     const foo = {};
     let res, buf2;
@@ -353,7 +352,7 @@ test('readFields', () => {
 });
 
 test('readMessage', () => {
-    const buf = new Pbf(fs.readFileSync(new URL('fixtures/12665.vector.pbf', import.meta.url))),
+    const buf = new PbfReader(fs.readFileSync(new URL('fixtures/12665.vector.pbf', import.meta.url))),
         layerNames = [],
         foo = {};
 
@@ -372,62 +371,62 @@ test('readMessage', () => {
 });
 
 test('field writing methods', () => {
-    const buf = new Pbf();
-    buf.writeFixed32Field(1, 100);
-    buf.writeFixed64Field(2, 200);
-    buf.writeVarintField(3, 1234);
-    buf.writeSVarintField(4, -599);
-    buf.writeStringField(5, 'Hello world');
-    buf.writeFloatField(6, 123);
-    buf.writeDoubleField(7, 123);
-    buf.writeBooleanField(8, true);
-    buf.writeBytesField(9, [1, 2, 3]);
-    buf.writeMessage(10, () => {
-        buf.writeBooleanField(1, true);
-        buf.writePackedVarint(2, testNumbers);
+    const writer = new PbfWriter();
+    writer.writeFixed32Field(1, 100);
+    writer.writeFixed64Field(2, 200);
+    writer.writeVarintField(3, 1234);
+    writer.writeSVarintField(4, -599);
+    writer.writeStringField(5, 'Hello world');
+    writer.writeFloatField(6, 123);
+    writer.writeDoubleField(7, 123);
+    writer.writeBooleanField(8, true);
+    writer.writeBytesField(9, new Uint8Array([1, 2, 3]));
+    writer.writeMessage(10, () => {
+        writer.writeBooleanField(1, true);
+        writer.writePackedVarint(2, testNumbers);
     });
 
-    buf.writeSFixed32Field(11, -123);
-    buf.writeSFixed64Field(12, -256);
+    writer.writeSFixed32Field(11, -123);
+    writer.writeSFixed64Field(12, -256);
 
-    buf.finish();
+    const reader = new PbfReader(writer.finish());
 
-    buf.readFields((tag) => {
-        if (tag === 1) buf.readFixed32();
-        else if (tag === 2) buf.readFixed64();
-        else if (tag === 3) buf.readVarint();
-        else if (tag === 4) buf.readSVarint();
-        else if (tag === 5) buf.readString();
-        else if (tag === 6) buf.readFloat();
-        else if (tag === 7) buf.readDouble();
-        else if (tag === 8) buf.readBoolean();
-        else if (tag === 9) buf.readBytes();
-        else if (tag === 10) buf.readMessage(() => { /* skip */ });
-        else if (tag === 11) buf.readSFixed32();
-        else if (tag === 12) buf.readSFixed64();
+    reader.readFields((tag) => {
+        if (tag === 1) reader.readFixed32();
+        else if (tag === 2) reader.readFixed64();
+        else if (tag === 3) reader.readVarint();
+        else if (tag === 4) reader.readSVarint();
+        else if (tag === 5) reader.readString();
+        else if (tag === 6) reader.readFloat();
+        else if (tag === 7) reader.readDouble();
+        else if (tag === 8) reader.readBoolean();
+        else if (tag === 9) reader.readBytes();
+        else if (tag === 10) reader.readMessage(() => { /* skip */ });
+        else if (tag === 11) reader.readSFixed32();
+        else if (tag === 12) reader.readSFixed64();
         else assert.fail('unknown tag');
     });
 });
 
 test('skip', () => {
-    const buf = new Pbf();
-    buf.writeFixed32Field(1, 100);
-    buf.writeFixed64Field(2, 200);
-    buf.writeVarintField(3, 1234);
-    buf.writeStringField(4, 'Hello world');
-    buf.finish();
+    const writer = new PbfWriter();
+    writer.writeFixed32Field(1, 100);
+    writer.writeFixed64Field(2, 200);
+    writer.writeVarintField(3, 1234);
+    writer.writeStringField(4, 'Hello world');
 
-    buf.readFields(() => { /* skip */ });
+    const reader = new PbfReader(writer.finish());
+    reader.readFields(() => { /* skip */ });
 
-    assert.equal(buf.pos, buf.length);
+    assert.equal(reader.pos, reader.length);
 
     assert.throws(() => {
-        buf.skip(6);
+        reader.skip(6);
     });
 });
 
 test('write a raw message > 0x10000000', () => {
-    const buf = new Pbf();
+    const buf = new PbfWriter();
     const marker = 0xdeadbeef;
     const encodedMarker = new Uint8Array([0xef, 0xbe, 0xad, 0xde]);
     const markerSize = encodedMarker.length;


### PR DESCRIPTION
**Breaking change:** the single `Pbf` class is split into `PbfReader` and `PbfWriter`, allowing readers and writers to be tree-shaken independently in bundled apps.

**Removed:** the legacy `readVarint64` method (replaced by `readVarint(true)` for signed 64-bit reads).

**Performance:** several targeted optimizations to both read and write hot paths, validated against `bench/bench-tiles.js`:
- `makeRoomForExtraLength` uses `Uint8Array.copyWithin` instead of a manual byte-shift loop (biggest write win).
- `writeVarint` gets a single-byte fast path, skipping the multi-byte branches and full `realloc(4)` for the common case (tags, small ints).
- `readVarint` gets a matching single-byte fast path.
- `writeBytes` uses `typedArray.set` instead of a manual loop.
README updated with fresh medians (3 runs of `bench/bench-tiles.js`, Node v26).
- **~18% faster decode** for the Mapbox vector-tile workload (~236 → ~200 ms, 159 → 187 MB/s) by rewriting reader codegen from a callback-style `pbf.readFields(cb, obj, end)` into inlined `while` loops with field-number dispatch. The win comes from eliminating megamorphic callback dispatch — V8 can now fully inline each generated reader.

End-to-end on the tile benchmark: write throughput improved from ~169 MB/s to ~215 MB/s (~27% faster), and read throughput from ~150 MB/s to ~187 MB/s (~25% faster).