### PR TITLE
Update protobuf.js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "benchmark": "^2.1.4",
         "eslint": "^10.4.0",
         "eslint-config-mourner": "^4.1.0",
-        "protobufjs": "^8.4.2",
+        "protobufjs": "^8.7.0",
         "protocol-buffers": "^5.0.0",
         "rollup": "^4.60.4",
         "typescript": "^6.0.3"
@@ -1476,11 +1476,10 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.2.tgz",
-      "integrity": "sha512-64rfNzkWOZAIazXzpBFPWq6F9up6gMvTzjE2oWIzApx2N/dqVUEE7+bCn2+40780dFVtKOUab8QfxJ6KJDWbqA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.0.tgz",
+      "integrity": "sha512-uu52JNxLh3vsL7tXU/h0gDaywufvuUCTbGSi0NKQKBZ2ZopkmrWQJSQO/EFqzu/5YhiwgVM8rq/a/iVpx4eZ0g==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "benchmark": "^2.1.4",
     "eslint": "^10.4.0",
     "eslint-config-mourner": "^4.1.0",
-    "protobufjs": "^8.4.2",
+    "protobufjs": "^8.7.0",
     "protocol-buffers": "^5.0.0",
     "rollup": "^4.60.4",
     "typescript": "^6.0.3"


### PR DESCRIPTION
Hey, protobuf.js maintainer here. Saw the benchmark already tracks a fairly recent version, nice, and was curious how our latest improvements compare to pbf's lean approach. Here's a bump to 8.7.0, see results on my machine below.

<details><summary>bench</summary>

```
decode vector tile with pbf x 2,975 ops/sec ±0.38% (98 runs sampled)
encode vector tile with pbf x 2,669 ops/sec ±0.99% (89 runs sampled)
decode vector tile with protocol-buffers x 1,932 ops/sec ±0.21% (98 runs sampled)
encode vector tile with protocol-buffers x 696 ops/sec ±0.62% (95 runs sampled)
decode vector tile with protobuf.js x 2,767 ops/sec ±0.24% (98 runs sampled)
encode vector tile with protobuf.js x 2,780 ops/sec ±0.85% (94 runs sampled)
JSON.parse vector tile x 801 ops/sec ±0.30% (96 runs sampled)
JSON.stringify vector tile x 600 ops/sec ±0.68% (91 runs sampled)
```
</details>

<details><summary>bench-tiles</summary>

```
439 tiles, 38512 KB pbf / 139439 KB JSON
pbf                decode: 161ms, 234 MB/s   encode: 120ms, 315 MB/s
protocol-buffers   decode: 202ms, 186 MB/s   encode: 490ms, 77 MB/s
protobuf.js        decode: 151ms, 250 MB/s   encode: 114ms, 331 MB/s
JSON               decode: 300ms, 453 MB/s   encode: 349ms, 391 MB/s
```
</details>